### PR TITLE
Update OpenAPI and Kotlin code generator to support deprecationNotice annotation

### DIFF
--- a/legal/headers/license-header-2025.txt
+++ b/legal/headers/license-header-2025.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2026 Contributors to the Eclipse Foundation
+Copyright (c) 2025 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,9 @@
                 <inherited>false</inherited>
                 <configuration>
                     <header>${project.basedir}/legal/headers/license-header.txt</header>
+                    <validHeaders>
+                        <header>${project.basedir}/legal/headers/license-header-2025.txt</header>
+                    </validHeaders>
                     <aggregate>true</aggregate>
                     <quiet>false</quiet>
                     <failIfMissing>true</failIfMissing>

--- a/wot-kotlin-generator/pom.xml
+++ b/wot-kotlin-generator/pom.xml
@@ -42,7 +42,7 @@
         <java.version>21</java.version>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <ditto-wot-model.version>3.8.6</ditto-wot-model.version>
+        <ditto-wot-model.version>3.8.12</ditto-wot-model.version>
         <kotlinx-coroutines.version>1.10.2</kotlinx-coroutines.version>
         <ktor-client.version>3.2.0</ktor-client.version>
         <jackson.version>2.20.1</jackson.version>
@@ -283,4 +283,3 @@
         </pluginManagement>
     </build>
 </project>
-

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/AnnotationUtils.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/AnnotationUtils.kt
@@ -19,7 +19,25 @@ import com.fasterxml.jackson.annotation.JsonSetter
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.json.JsonPointer
+import org.eclipse.ditto.json.JsonValue
 import org.eclipse.ditto.wot.kotlin.generator.common.model.DittoJsonDsl
+import org.eclipse.ditto.wot.model.Action
+import org.eclipse.ditto.wot.model.Property
+import org.eclipse.ditto.wot.model.SingleDataSchema
+import kotlin.jvm.optionals.getOrNull
+
+private const val DITTO_DEPRECATION_NOTICE = "ditto:deprecationNotice"
+private const val DEPRECATED = "deprecated"
+private const val SUPERSEDED_BY = "supersededBy"
+private const val REMOVAL_VERSION = "removalVersion"
+
+data class DeprecationNotice(
+    val deprecated: Boolean,
+    val supersededBy: String? = null,
+    val removalVersion: String? = null
+)
 
 fun buildDittoJsonDslAnnotationSpec(): AnnotationSpec {
     return AnnotationSpec.builder(DittoJsonDsl::class)
@@ -66,4 +84,79 @@ fun buildJsonSetterAnnotationSpec(originalPropertyName: String): AnnotationSpec 
     return AnnotationSpec.builder(JsonSetter::class)
         .addMember("%S", originalPropertyName)
         .build()
+}
+
+fun extractDeprecationNotice(property: Property): DeprecationNotice? = extractDeprecationNotice(property.toJson())
+
+fun extractDeprecationNotice(action: Action): DeprecationNotice? = extractDeprecationNotice(action.toJson())
+
+fun extractDeprecationNotice(schema: SingleDataSchema): DeprecationNotice? = extractDeprecationNotice(schema.toJson())
+
+fun extractDeprecationNotice(jsonObject: JsonObject): DeprecationNotice? {
+    val deprecationNotice = jsonObject.getValue(JsonPointer.of(DITTO_DEPRECATION_NOTICE))
+        .getOrNull()
+        ?.takeIf(JsonValue::isObject)
+        ?.asObject()
+        ?: return null
+
+    val deprecatedValue = deprecationNotice.getValue(JsonPointer.of(DEPRECATED))
+        .getOrNull()
+        ?: return null
+
+    if (!deprecatedValue.isBoolean || !deprecatedValue.asBoolean()) {
+        return null
+    }
+
+    val supersededBy = deprecationNotice.getValue(JsonPointer.of(SUPERSEDED_BY))
+        .getOrNull()
+        ?.takeIf(JsonValue::isString)
+        ?.asString()
+
+    val removalVersion = deprecationNotice.getValue(JsonPointer.of(REMOVAL_VERSION))
+        .getOrNull()
+        ?.takeIf(JsonValue::isString)
+        ?.asString()
+
+    return DeprecationNotice(
+        deprecated = true,
+        supersededBy = supersededBy,
+        removalVersion = removalVersion
+    )
+}
+
+fun deprecationReplacementIdentifier(notice: DeprecationNotice?): String? {
+    val pointer = notice?.supersededBy ?: return null
+    if (!pointer.startsWith("#/")) return null
+    val targetName = pointer.substringAfterLast('/').takeIf { it.isNotBlank() } ?: return null
+    return asPropertyName(targetName)
+}
+
+fun buildDeprecationMessage(
+    notice: DeprecationNotice,
+    replacementIdentifier: String? = deprecationReplacementIdentifier(notice)
+): String {
+    val parts = mutableListOf<String>()
+    if (replacementIdentifier != null) {
+        parts.add("Use $replacementIdentifier() instead.")
+    } else {
+        parts.add("This element is deprecated.")
+    }
+    notice.removalVersion?.let { parts.add("Will be removed in version $it.") }
+    return parts.joinToString(" ")
+}
+
+fun buildDeprecatedAnnotationSpec(
+    notice: DeprecationNotice,
+    replaceWithExpression: String? = null
+): AnnotationSpec {
+    val replacementIdentifier = deprecationReplacementIdentifier(notice)
+    val message = buildDeprecationMessage(notice, replacementIdentifier)
+    val effectiveReplaceWith = replaceWithExpression ?: replacementIdentifier?.let { "$it()" }
+    val deprecatedAnnotation = AnnotationSpec.builder(Deprecated::class)
+        .addMember("message = %S", message)
+    if (effectiveReplaceWith != null) {
+        deprecatedAnnotation.addMember("replaceWith = %T(%S)", ClassName("kotlin", "ReplaceWith"), effectiveReplaceWith)
+    }
+    deprecatedAnnotation.addMember("level = %T.WARNING", DeprecationLevel::class)
+    return deprecatedAnnotation.build()
 }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/AnnotationUtils.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/AnnotationUtils.kt
@@ -155,7 +155,7 @@ fun buildDeprecatedAnnotationSpec(
     val deprecatedAnnotation = AnnotationSpec.builder(Deprecated::class)
         .addMember("message = %S", message)
     if (effectiveReplaceWith != null) {
-        deprecatedAnnotation.addMember("replaceWith = %T(%S)", ClassName("kotlin", "ReplaceWith"), effectiveReplaceWith)
+        deprecatedAnnotation.addMember("replaceWith = %T(%S)", ReplaceWith::class, effectiveReplaceWith)
     }
     deprecatedAnnotation.addMember("level = %T.WARNING", DeprecationLevel::class)
     return deprecatedAnnotation.build()

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DeprecationNoticeGenerationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DeprecationNoticeGenerationTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.common
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.kotlin.generator.plugin.ThingModelGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
+import org.eclipse.ditto.wot.model.ThingModel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DeprecationNoticeGenerationTest {
+
+    @Test
+    fun `deprecated notice generates kotlin deprecated annotations`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-deprecation-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Deprecation Demo Thing",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "legacyLocation": {
+                          "title": "Legacy Location",
+                          "type": "object",
+                          "properties": {
+                            "street": { "type": "string" }
+                          },
+                          "ditto:deprecationNotice": {
+                            "deprecated": true,
+                            "supersededBy": "#/properties/newLocation",
+                            "removalVersion": "2.0.0"
+                          }
+                        },
+                        "newLocation": {
+                          "title": "New Location",
+                          "type": "object",
+                          "properties": {
+                            "street": { "type": "string" }
+                          }
+                        }
+                      },
+                      "actions": {
+                        "legacyAction": {
+                          "title": "Legacy Action",
+                          "input": { "type": "string" },
+                          "ditto:deprecationNotice": {
+                            "deprecated": true,
+                            "supersededBy": "#/actions/newAction",
+                            "removalVersion": "2.0.0"
+                          }
+                        },
+                        "newAction": {
+                          "title": "New Action",
+                          "input": { "type": "string" }
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.deprecationtest"
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val actionFile = outputDir.resolve("$packagePath/actions/LegacyAction.kt")
+
+            assertTrue(Files.exists(attributesFile), "Expected generated attributes file at: $attributesFile")
+            assertTrue(Files.exists(actionFile), "Expected generated action file at: $actionFile")
+
+            val attributesContent = Files.readString(attributesFile)
+            val actionContent = Files.readString(actionFile)
+
+            assertTrue(
+                Regex("(?s)@Deprecated\\(.*newLocation\\(\\).*\\)\\s*(public\\s+)?(override\\s+)?var legacyLocation")
+                    .containsMatchIn(attributesContent),
+                "Expected legacyLocation property to be annotated as deprecated"
+            )
+            assertTrue(
+                Regex("(?s)@Deprecated\\(.*newLocation\\(block\\).*\\)\\s*(public\\s+)?(suspend\\s+)?fun legacyLocation\\(")
+                    .containsMatchIn(attributesContent),
+                "Expected legacyLocation DSL builder function to be annotated as deprecated"
+            )
+            assertTrue(
+                actionContent.contains("@Deprecated(") &&
+                    actionContent.contains("legacyAction(") &&
+                    actionContent.contains("Will be removed in version 2.0.0."),
+                "Expected legacyAction function to be annotated as deprecated"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    private fun deleteRecursively(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+}

--- a/wot-to-openapi-generator/pom.xml
+++ b/wot-to-openapi-generator/pom.xml
@@ -37,7 +37,7 @@
         <kotlin.stdlib.version>2.2.10</kotlin.stdlib.version>
         <kotlin.compiler.apiVersion>2.0</kotlin.compiler.apiVersion>
 
-        <ditto.version>3.8.6</ditto.version>
+        <ditto.version>3.8.12</ditto.version>
         <kotlinx-coroutines.version>1.10.2</kotlinx-coroutines.version>
         <ktor-client.version>3.2.0</ktor-client.version>
         <caffeine.version>3.2.2</caffeine.version>

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/Utils.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/Utils.kt
@@ -453,7 +453,7 @@ object Utils {
 
     /**
      * Extracts the Ditto deprecation notice from a generic interaction JSON object.
-     * The notice is considered valid only if `deprecated` is present and boolean.
+     * The notice is considered valid only if `deprecated` is present, boolean and true.
      */
     fun extractDeprecationNotice(interactionJson: JsonObject): DeprecationNotice? {
         val deprecationNotice = interactionJson.getValue(JsonPointer.of(DITTO_DEPRECATION_NOTICE))
@@ -466,7 +466,7 @@ object Utils {
             .getOrNull()
             ?: return null
 
-        if (!deprecatedValue.isBoolean) {
+        if (!deprecatedValue.isBoolean || !deprecatedValue.asBoolean()) {
             return null
         }
 
@@ -481,7 +481,7 @@ object Utils {
             ?.asString()
 
         return DeprecationNotice(
-            deprecated = deprecatedValue.asBoolean(),
+            deprecated = true,
             supersededBy = supersededBy,
             removalVersion = removalVersion
         )

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeatureActionsPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeatureActionsPathsGenerator.kt
@@ -25,6 +25,8 @@ import io.swagger.v3.oas.models.responses.ApiResponses
 import org.eclipse.ditto.wot.model.Action
 import org.eclipse.ditto.wot.model.ThingModel
 import org.eclipse.ditto.wot.openapi.generator.Utils.asOpenApiSchema
+import org.eclipse.ditto.wot.openapi.generator.Utils.extractDeprecationNotice
+import org.eclipse.ditto.wot.openapi.generator.Utils.mergeWithDeprecationNotice
 import org.eclipse.ditto.wot.openapi.generator.providers.ApiResponsesProvider
 import org.eclipse.ditto.wot.openapi.generator.providers.ParametersProvider
 import org.eclipse.ditto.wot.openapi.generator.providers.addApiResponse
@@ -48,10 +50,13 @@ object FeatureActionsPathsGenerator {
     }
 
     private fun providePathForAction(featureTitle: String, featureName: String, action: Action, openAPI: OpenAPI): PathItem {
+        val deprecationNotice = extractDeprecationNotice(action)
+        val deprecated = deprecationNotice?.deprecated == true
 
         val operation = Operation()
+            .also { if (deprecated) it.deprecated(true) }
             .summary("Invokes the '${action.title.getOrNull()?.toString()}' action")
-            .description(action.description.getOrNull()?.toString())
+            .description(mergeWithDeprecationNotice(action.description.getOrNull()?.toString(), deprecationNotice))
             .tags(listOf("Feature: $featureTitle - Actions"))
             .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
             .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CONDITION) })

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/ActionsPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/ActionsPathsGenerator.kt
@@ -25,6 +25,8 @@ import io.swagger.v3.oas.models.responses.ApiResponses
 import org.eclipse.ditto.wot.model.Action
 import org.eclipse.ditto.wot.model.ThingModel
 import org.eclipse.ditto.wot.openapi.generator.Utils.asOpenApiSchema
+import org.eclipse.ditto.wot.openapi.generator.Utils.extractDeprecationNotice
+import org.eclipse.ditto.wot.openapi.generator.Utils.mergeWithDeprecationNotice
 import org.eclipse.ditto.wot.openapi.generator.providers.ApiResponsesProvider
 import org.eclipse.ditto.wot.openapi.generator.providers.ParametersProvider
 import org.eclipse.ditto.wot.openapi.generator.providers.addApiResponse
@@ -44,10 +46,13 @@ object ActionsPathsGenerator {
     }
 
     private fun providePathForAction(action: Action, openAPI: OpenAPI): PathItem {
+        val deprecationNotice = extractDeprecationNotice(action)
+        val deprecated = deprecationNotice?.deprecated == true
 
         val operation = Operation()
+            .also { if (deprecated) it.deprecated(true) }
             .summary("Invokes the '${action.title.getOrNull()?.toString()}' action")
-            .description(action.description.getOrNull()?.toString())
+            .description(mergeWithDeprecationNotice(action.description.getOrNull()?.toString(), deprecationNotice))
             .tags(listOf("Actions"))
             .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
             .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CONDITION) })

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/AttributeSchemaResolver.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/AttributeSchemaResolver.kt
@@ -197,9 +197,6 @@ object AttributeSchemaResolver {
                 val itemSchema = getSchema(itemsObject ?: JsonObject.empty()) ?: schema as Schema<Any>
                 itemSchema.title = itemsObject?.getValue("title")?.getOrNull()?.asString()
                 itemSchema.description = itemsObject?.getValue("description")?.getOrNull()?.asString()
-                if (itemsObject != null && extractDeprecationNotice(itemsObject)?.deprecated == true) {
-                    itemSchema.deprecated(true)
-                }
 
                 if (itemSchema is ObjectSchema) {
                     val properties = createSubSchemaProperties(

--- a/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
+++ b/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
@@ -54,6 +54,17 @@ class DeprecationNoticeAndPathsTest {
             }
             """.trimIndent()
         )
+        val notDeprecatedJson = JsonObject.of(
+            """
+            {
+              "ditto:deprecationNotice": {
+                "deprecated": false,
+                "supersededBy": "#/properties/targetTemperature",
+                "removalVersion": "2.0.0"
+              }
+            }
+            """.trimIndent()
+        )
 
         val validNotice = Utils.extractDeprecationNotice(validJson)
         assertNotNull(validNotice)
@@ -63,6 +74,9 @@ class DeprecationNoticeAndPathsTest {
 
         val invalidNotice = Utils.extractDeprecationNotice(invalidJson)
         assertNull(invalidNotice)
+
+        val notDeprecatedNotice = Utils.extractDeprecationNotice(notDeprecatedJson)
+        assertNull(notDeprecatedNotice)
     }
 
     @Test

--- a/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
+++ b/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.openapi.generator
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Paths
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.model.ThingModel
+import org.eclipse.ditto.wot.openapi.generator.features.FeatureActionsPathsGenerator
+import org.eclipse.ditto.wot.openapi.generator.features.FeaturesPathsGenerator
+import org.eclipse.ditto.wot.openapi.generator.thing.AttributeSchemaResolver
+import org.eclipse.ditto.wot.openapi.generator.thing.ActionsPathsGenerator
+import org.eclipse.ditto.wot.openapi.generator.thing.AttributesPathsGenerator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertContains
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DeprecationNoticeAndPathsTest {
+
+    @Test
+    fun `extract valid deprecation notice and ignore invalid one`() {
+        val validJson = JsonObject.of(
+            """
+            {
+              "ditto:deprecationNotice": {
+                "deprecated": true,
+                "supersededBy": "#/properties/targetTemperature",
+                "removalVersion": "2.0.0"
+              }
+            }
+            """.trimIndent()
+        )
+        val invalidJson = JsonObject.of(
+            """
+            {
+              "ditto:deprecationNotice": {
+                "supersededBy": "#/properties/targetTemperature",
+                "removalVersion": "2.0.0"
+              }
+            }
+            """.trimIndent()
+        )
+
+        val validNotice = Utils.extractDeprecationNotice(validJson)
+        assertNotNull(validNotice)
+        assertTrue(validNotice.deprecated)
+        assertEquals("#/properties/targetTemperature", validNotice.supersededBy)
+        assertEquals("2.0.0", validNotice.removalVersion)
+
+        val invalidNotice = Utils.extractDeprecationNotice(invalidJson)
+        assertNull(invalidNotice)
+    }
+
+    @Test
+    fun `mark thing attribute and action operations as deprecated when extension says deprecated true`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Thermostat",
+              "properties": {
+                "tempSetpoint": {
+                  "title": "Temperature Setpoint",
+                  "type": "number",
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/properties/targetTemperature",
+                    "removalVersion": "2.0.0"
+                  }
+                }
+              },
+              "actions": {
+                "setTemp": {
+                  "title": "Set Temperature",
+                  "input": { "type": "number" },
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/actions/setTargetTemperature",
+                    "removalVersion": "2.0.0"
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        AttributesPathsGenerator.generateThingAttributesPaths(model, paths, api)
+        ActionsPathsGenerator.generateThingActionsPaths(model, paths, api)
+
+        val attributePath = paths["/{thingId}/attributes/tempSetpoint"]
+        assertTrue(attributePath?.get?.deprecated == true)
+        assertTrue(attributePath?.put?.deprecated == true)
+        assertTrue(attributePath?.patch?.deprecated == true)
+
+        val actionPost = paths["/{thingId}/inbox/messages/setTemp"]?.post
+        assertTrue(actionPost?.deprecated == true)
+    }
+
+    @Test
+    fun `mark feature property and action operations as deprecated when extension says deprecated true`() {
+        val featureModel = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Thermostat Feature",
+              "properties": {
+                "tempSetpoint": {
+                  "title": "Temperature Setpoint",
+                  "type": "number",
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/properties/targetTemperature",
+                    "removalVersion": "2.0.0"
+                  }
+                }
+              },
+              "actions": {
+                "setTemp": {
+                  "title": "Set Temperature",
+                  "input": { "type": "number" },
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/actions/setTargetTemperature",
+                    "removalVersion": "2.0.0"
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("thermostat", featureModel, paths, api)
+        FeatureActionsPathsGenerator.generateFeatureActionsPaths("thermostat", featureModel, paths, api)
+
+        val propertyPath = paths["/{thingId}/features/thermostat/properties/tempSetpoint"]
+        assertTrue(propertyPath?.get?.deprecated == true)
+        assertTrue(propertyPath?.put?.deprecated == true)
+        assertTrue(propertyPath?.patch?.deprecated == true)
+
+        val actionPost = paths["/{thingId}/features/thermostat/inbox/messages/setTemp"]?.post
+        assertTrue(actionPost?.deprecated == true)
+    }
+
+    @Test
+    fun `deprecated field is absent (null) for non-deprecated thing attribute operations`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Thermostat",
+              "properties": {
+                "targetTemperature": {
+                  "title": "Target Temperature",
+                  "type": "number"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        AttributesPathsGenerator.generateThingAttributesPaths(model, paths, openApi())
+
+        val path = paths["/{thingId}/attributes/targetTemperature"]
+        assertNull(path?.get?.deprecated)
+        assertNull(path?.put?.deprecated)
+        assertNull(path?.patch?.deprecated)
+    }
+
+    @Test
+    fun `deprecated thing attribute marks response and component schemas deprecated`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Thermostat",
+              "properties": {
+                "tempSetpoint": {
+                  "title": "Temperature Setpoint",
+                  "type": "number",
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/properties/targetTemperature",
+                    "removalVersion": "2.0.0"
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        AttributesPathsGenerator.generateThingAttributesPaths(model, paths, api)
+
+        val responseSchema = paths["/{thingId}/attributes/tempSetpoint"]
+            ?.get?.responses?.get("200")?.content?.get("application/json")?.schema
+        assertTrue(responseSchema?.deprecated == true)
+        api.schema("attributes", AttributeSchemaResolver.provideAttributesSchema(model, api))
+
+        val componentSchema = api.components.schemas["attribute_tempSetpoint"]
+        assertNotNull(componentSchema)
+        assertTrue(componentSchema.deprecated == true)
+
+        val attributesSchema = api.components.schemas["attributes"]
+        val attributeEntrySchema = attributesSchema?.properties?.get("tempSetpoint")
+        assertNotNull(attributeEntrySchema)
+        assertTrue(attributeEntrySchema.deprecated == true)
+    }
+
+    @Test
+    fun `response schema is marked deprecated for deprecated feature property`() {
+        val featureModel = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Thermostat Feature",
+              "properties": {
+                "tempSetpoint": {
+                  "title": "Temperature Setpoint",
+                  "type": "number",
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/properties/targetTemperature",
+                    "removalVersion": "2.0.0"
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("thermostat", featureModel, paths, api)
+
+        val responseSchema = paths["/{thingId}/features/thermostat/properties/tempSetpoint"]
+            ?.get?.responses?.get("200")?.content?.get("application/json")?.schema
+        assertTrue(responseSchema?.deprecated == true)
+    }
+
+    @Test
+    fun `build deprecation description with and without optional fields`() {
+        val notice = Utils.DeprecationNotice(
+            deprecated = true,
+            supersededBy = "#/properties/targetTemperature",
+            removalVersion = "2.0.0"
+        )
+        val text = Utils.buildDeprecationDescription(notice)
+        assertNotNull(text)
+        assertContains(text, "**Deprecated.**")
+        assertContains(text, "`#/properties/targetTemperature`")
+        assertContains(text, "2.0.0")
+
+        val minimalText = Utils.buildDeprecationDescription(Utils.DeprecationNotice(deprecated = true))
+        assertNotNull(minimalText)
+        assertContains(minimalText, "**Deprecated.**")
+    }
+
+    @Test
+    fun `operation descriptions contain deprecation notice text for deprecated thing interactions`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Thermostat",
+              "properties": {
+                "tempSetpoint": {
+                  "title": "Temperature Setpoint",
+                  "description": "The current setpoint.",
+                  "type": "number",
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/properties/targetTemperature",
+                    "removalVersion": "2.0.0"
+                  }
+                }
+              },
+              "actions": {
+                "setTemp": {
+                  "title": "Set Temperature",
+                  "description": "Sets the temperature.",
+                  "input": { "type": "number" },
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/actions/setTargetTemperature",
+                    "removalVersion": "2.0.0"
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        AttributesPathsGenerator.generateThingAttributesPaths(model, paths, api)
+        ActionsPathsGenerator.generateThingActionsPaths(model, paths, api)
+
+        val attributeDescription = paths["/{thingId}/attributes/tempSetpoint"]?.get?.description
+        assertNotNull(attributeDescription)
+        assertContains(attributeDescription, "The current setpoint.")
+        assertContains(attributeDescription, "**Deprecated.**")
+        assertContains(attributeDescription, "`#/properties/targetTemperature`")
+        assertContains(attributeDescription, "2.0.0")
+
+        val actionDescription = paths["/{thingId}/inbox/messages/setTemp"]?.post?.description
+        assertNotNull(actionDescription)
+        assertContains(actionDescription, "Sets the temperature.")
+        assertContains(actionDescription, "**Deprecated.**")
+        assertContains(actionDescription, "`#/actions/setTargetTemperature`")
+        assertContains(actionDescription, "2.0.0")
+    }
+
+    private fun thingModelFromJson(json: String): ThingModel =
+        ThingModel.fromJson(JsonObject.of(json))
+
+    private fun openApi() = OpenAPI().components(Components().schemas(mutableMapOf()))
+}


### PR DESCRIPTION
This PR adds support for ditto:deprecationNotice in both generators (OpenAPI + Kotlin), so deprecations defined in WoT models are reflected in generated artifacts.

**OpenAPI changes**

- Sets deprecated: true on affected operations.
- Sets deprecated: true on affected schemas (including referenced component schemas), not just paths.
- Appends deprecation migration info (replacement/removal version) to operation descriptions.

**Kotlin changes**

- Generates Kotlin @Deprecated annotations for deprecated properties/actions (including DSL/accessor usage where applicable).
- Fills message, [replaceWith = ReplaceWith(...)](https://file+.vscode-resource.vscode-cdn.net/Users/hussein_ahmed/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#), and DeprecationLevel.WARNING from deprecation notice metadata.