### PR TITLE
Add submodel-only generation mode to Kotlin generator

### DIFF
--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/README.md
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/README.md
@@ -82,7 +82,56 @@ The WoT Kotlin Generator consists of two Maven modules:
 | `enumGenerationStrategy` | String | No | `INLINE` | Strategy for generating enums (`INLINE` or `SEPARATE_CLASS`)             |
 | `classNamingStrategy` | String | No | `COMPOUND_ALL` | Strategy for naming classes (`COMPOUND_ALL` or `ORIGINAL_THEN_COMPOUND`) |
 | `generateSuspendDsl` | boolean | No | `false` | Whether DSL functions should be suspend functions                        |
+| `submodelOnly` | boolean | No | `false` | Generate a self-contained submodel package instead of a full device model |
+| `featureName` | String | No | _(camelCase of model title)_ | JSON key for the feature when using `submodelOnly`                       |
 
+
+## Submodel-Only Mode
+
+When a WoT Thing Model represents a shared capability referenced by multiple device types (e.g. a thermostat submodel used by both a Temperature Thermostat and a Room Controller), use `submodelOnly=true` to generate a self-contained package without device-specific wrappers.
+
+### What Gets Generated
+
+Instead of a full device model (attributes, multi-feature wrapper, top-level Thing class), the generator produces:
+
+```
+generated-sources/
+└── com/example/iot/thermostat/
+    ├── ThermostatThing.kt              # Device-agnostic Thing<Nothing, ThermostatFeatures>
+    └── features/
+        ├── ThermostatFeatures.kt       # Single-feature Features container
+        └── thermostat/
+            ├── Thermostat.kt           # Feature class with FEATURE_NAME and startPath()
+            ├── ThermostatProperties.kt # Feature properties
+            └── properties/
+                └── *.kt               # Individual property classes
+```
+
+### Configuration
+
+```xml
+<execution>
+    <id>code-generator-thermostat-submodel</id>
+    <phase>generate-sources</phase>
+    <goals><goal>codegen</goal></goals>
+    <configuration>
+        <thingModelUrl>https://example.org/thermostat-2.0.0.tm.jsonld</thingModelUrl>
+        <packageName>com.example.iot.thermostat</packageName>
+        <classNamingStrategy>ORIGINAL_THEN_COMPOUND</classNamingStrategy>
+        <submodelOnly>true</submodelOnly>
+        <featureName>thermostat</featureName>
+    </configuration>
+</execution>
+```
+
+### The `featureName` Parameter
+
+The `featureName` sets the JSON key used for `@JsonSetter`, `@JsonProperty`, and `FEATURE_NAME` in the generated feature class — this must match the exact key used in the Ditto digital twin JSON. It mirrors the link instance name used in parent device models.
+
+- **If set**: used verbatim (e.g. `"temperature-thermostat"` → `@JsonSetter("temperature-thermostat")`)
+- **If not set**: derived from the model title in camelCase (e.g. title `"Thermostat"` → `"thermostat"`)
+
+Always set `featureName` explicitly when the JSON key contains hyphens or differs from the camelCase title.
 
 ## Configuration Strategies
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/ThingModelGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/ThingModelGenerator.kt
@@ -102,9 +102,6 @@ object ThingModelGenerator {
      * @param config The configuration controlling the generation process
      */
     suspend fun generate(thingModel: ThingModel, config: GeneratorConfiguration) {
-        val modelName = asClassNameWithStrategy(thingModel.title.get().toString(), null, config.classNamingStrategy, emptySet())
-        val links = thingModel.links.getOrNull() ?: emptyList<BaseLink<*>>()
-
         logger.info("Using enum generation strategy: ${config.enumGenerationStrategy}")
         logger.info("Generate DSL: ${config.generateDsl}")
         logger.info("Generate Enums: ${config.generateEnums}")
@@ -116,6 +113,19 @@ object ThingModelGenerator {
         // Set enum generation strategy in WrapperTypeChecker
         val enumStrategy = EnumGenerationStrategyFactory.createStrategy(config)
         org.eclipse.ditto.wot.kotlin.generator.plugin.property.WrapperTypeChecker.setEnumGenerationStrategy(enumStrategy)
+
+        if (!config.submodelOnly && config.featureName != null) {
+            logger.warn("featureName is set but submodelOnly is false - featureName will be ignored")
+        }
+
+        if (config.submodelOnly) {
+            logger.info("Submodel-only mode: generating self-contained submodel package for '${thingModel.title.get()}'")
+            classGenerator.generateSubmodelFeature(config.outputPackage, thingModel)
+            return
+        }
+
+        val modelName = asClassNameWithStrategy(thingModel.title.get().toString(), null, config.classNamingStrategy, emptySet())
+        val links = thingModel.links.getOrNull() ?: emptyList<BaseLink<*>>()
 
         classGenerator.generateAttributesClass(config.outputPackage, thingModel)
         classGenerator.generateThingActions(config.outputPackage, thingModel)

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/WotKotlinCodegenMojo.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/WotKotlinCodegenMojo.kt
@@ -91,6 +91,23 @@ class WotKotlinCodegenMojo: AbstractMojo() {
     var generateInterfaces: Boolean = true
 
     /**
+     * When true, generates a self-contained submodel package: feature classes, a single-feature
+     * Features container, and a device-agnostic Thing — without attributes or multi-device wrappers.
+     * Use for shared submodels referenced by multiple device types.
+     */
+    @Parameter(property = "submodelOnly", defaultValue = "false")
+    var submodelOnly: Boolean = false
+
+    /**
+     * The feature name (JSON key) to use when generating in submodel-only mode.
+     * If not set, the name is derived from the model title in camelCase.
+     * Only used when submodelOnly is true.
+     */
+    @Parameter(property = "featureName")
+    var featureName: String? = null
+
+
+    /**
      * Main execution method called by Maven during the build lifecycle.
      *
      * This method:
@@ -123,6 +140,8 @@ class WotKotlinCodegenMojo: AbstractMojo() {
             log.info("---> Generate Suspend DSL: ${config.generateSuspendDsl}")
             log.info("---> Generate Enums: ${config.generateEnums}")
             log.info("---> Generate Interfaces: ${config.generateInterfaces}")
+            log.info("---> Submodel only: ${config.submodelOnly}")
+            log.info("---> Feature name: ${config.featureName ?: "<derived from model title>"}")
 
             runBlocking {
                 GeneratorStarter.run(config)
@@ -195,7 +214,9 @@ class WotKotlinCodegenMojo: AbstractMojo() {
             generateDsl = generateDsl,
             generateSuspendDsl = generateSuspendDsl,
             generateEnums = generateEnums,
-            generateInterfaces = generateInterfaces
+            generateInterfaces = generateInterfaces,
+            submodelOnly = submodelOnly,
+            featureName = featureName
         )
     }
 }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
@@ -163,6 +163,38 @@ object ClassGenerator {
     }
 
     /**
+     * Generates a self-contained set of classes from a shared submodel, mirroring the
+     * structure of a full device model but without attributes and with a single feature.
+     *
+     * Produces (under [packageName]):
+     * - `features/{featureName}/FeatureClass.kt` — feature and properties classes
+     * - `features/FeatureNameFeatures.kt` — device-agnostic Features container
+     * - `FeatureNameThing.kt` — device-agnostic Thing extending [Thing]<[Nothing], FeatureNameFeatures>
+     *
+     * Used when [GeneratorConfiguration.submodelOnly] is true.
+     *
+     * @param packageName The root package for all generated classes
+     * @param featureModel The WoT Thing Model representing the submodel
+     */
+    suspend fun generateSubmodelFeature(packageName: String, featureModel: ThingModel) {
+        val featuresPackage = "$packageName.features"
+        val canonicalFeatureName = config?.featureName
+            ?: asPropertyName(featureModel.title.get().toString())
+        val (featurePropertySpec, originalFeatureName) = generateSingleFeature(
+            featureModel, canonicalFeatureName, featuresPackage
+        )
+        val featureClassName = asClassName(asPropertyName(originalFeatureName))
+
+        generateFeaturesClassFromFeatures(
+            "${featureClassName}Features",
+            listOf(Pair(featurePropertySpec, originalFeatureName)),
+            featuresPackage,
+            originalName = "features"
+        )
+        generateSubmodelThingWrapper(featureClassName, packageName, featuresPackage)
+    }
+
+    /**
      * Generates a new class and writes it to the output directory.
      *
      * Creates a Kotlin class file with the specified type specification, adds
@@ -469,48 +501,42 @@ object ClassGenerator {
         dslGenerator.generateAttributesOrFeaturesDslFunSpec("features", featuresName, featuresPackage)
 
 
+    private suspend fun generateSingleFeature(
+        featureModel: ThingModel,
+        originalFeatureName: String,
+        featuresPackageName: String
+    ): Pair<PropertySpec, String> {
+        val propertyName = asPropertyName(originalFeatureName)
+        val featurePackage = "$featuresPackageName.${asPackageName(originalFeatureName)}"
+        val linkProperties = propertyResolver.resolveProperties(
+            featureModel.properties.getOrNull(), "$featurePackage.properties",
+            PropertyRole.nextLevel(PropertyRole.FEATURE), propertyName
+        )
+        generateCategoryMarkerClasses(linkProperties.values.filterNotNull(), featuresPackageName)
+        if (linkProperties.isNotEmpty()) {
+            generateFeaturePropertiesClass(
+                asClassName(propertyName), linkProperties, featurePackage, featuresPackageName, originalFeatureName
+            )
+        }
+        generateFeatureClassFromProperties(
+            originalFeatureName, asClassName(propertyName), featurePackage,
+            featureModel.properties.getOrNull(), featureModel.actions.getOrNull()
+        )
+        return Pair(
+            PropertySpec.builder(
+                propertyName, ClassName(featurePackage, asClassName(propertyName)).copy(nullable = true)
+            ).mutable(true).initializer("null").build(),
+            originalFeatureName
+        )
+    }
+
     private suspend fun resolveFeatures(
         links: Iterable<BaseLink<*>>,
         featuresPackageName: String
     ): List<Pair<PropertySpec, String>> {
         return links.filter { LinkRelationType.isSubmodel(it) }.map {
             val featureModel = ThingModelGenerator.loadModel(it.href.toString())
-            val originalFeatureName = getLinkInstanceName(it)
-            val propertyName = asPropertyName(originalFeatureName)
-            val packageName = "${featuresPackageName}.${asPackageName(originalFeatureName)}"
-            val role = PropertyRole.FEATURE
-            val linkProperties = propertyResolver.resolveProperties(
-                featureModel.properties.getOrNull(), "$packageName.properties", PropertyRole.nextLevel(role),
-                propertyName
-            )
-
-            val allProps2Category = linkProperties
-
-            generateCategoryMarkerClasses(
-                allProps2Category.values.filterNotNull(), featuresPackageName
-            )
-
-            if (allProps2Category.isNotEmpty()) {
-                generateFeaturePropertiesClass(
-                    asClassName(propertyName),
-                    allProps2Category,
-                    packageName,
-                    featuresPackageName,
-                    originalFeatureName
-                )
-            }
-
-            val wotProperties = featureModel.properties.getOrNull()
-            val wotActions = featureModel.actions.getOrNull()
-            generateFeatureClassFromProperties(
-                originalFeatureName, asClassName(propertyName), packageName, wotProperties, wotActions
-            )
-            Pair(
-                PropertySpec.builder(
-                    propertyName, ClassName(packageName, asClassName(propertyName)).copy(nullable = true)
-                ).mutable(true).initializer("null").build(),
-                originalFeatureName
-            )
+            generateSingleFeature(featureModel, getLinkInstanceName(it), featuresPackageName)
         }
     }
 
@@ -835,7 +861,7 @@ object ClassGenerator {
     }
 
     private fun generateFeaturesClassFromFeatures(className: String, properties: List<Pair<PropertySpec, String>>,
-                                                  packageName: String) {
+                                                  packageName: String, originalName: String? = null) {
         val featureDslFunsSpecs = properties.map {
             val propClassName = it.first.type as ClassName
             dslGenerator.generateFeatureDslFunSpec(propClassName.simpleName, propClassName.packageName)
@@ -885,7 +911,8 @@ object ClassGenerator {
             typeSpec,
             className,
             packageName,
-            listOf(dslGenerator.generateFeatureDslFunSpec(className, packageName, true))
+            listOf(dslGenerator.generateFeatureDslFunSpec(className, packageName, true)),
+            originalName = originalName
         )
     }
 
@@ -1709,5 +1736,30 @@ object ClassGenerator {
             role
         )?.let { fieldsDslFunSpecs += it }
         return fieldsDslFunSpecs
+    }
+
+
+    private fun generateSubmodelThingWrapper(featureClassName: String, packageName: String,
+                                             featuresPackage: String) {
+        val thingClassName = "${featureClassName}Thing"
+        val featuresClassName = "${featureClassName}Features"
+
+        val typeSpecBuilder = TypeSpec.classBuilder(thingClassName)
+            .addAnnotation(buildDittoJsonDslAnnotationSpec())
+            .addAnnotation(buildJsonIncludeAnnotationSpec())
+            .addAnnotation(buildJsonIgnoreAnnotationSpec())
+            .superclass(
+                ClassName(Const.COMMON_PACKAGE, "Thing")
+                    .parameterizedBy(NOTHING, ClassName(featuresPackage, featuresClassName))
+            )
+            .addFunction(generateFeaturesDslFunSpec(featuresClassName, featuresPackage))
+
+        val topLevelDslFun = dslGenerator.generateFeatureDslFunSpec(thingClassName, packageName, true)
+
+        FileSpec.builder(packageName, thingClassName)
+            .addType(typeSpecBuilder.build())
+            .addFunction(topLevelDslFun)
+            .build()
+            .writeTo(Path(outputDir))
     }
 }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/ConfigurationBuilder.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/ConfigurationBuilder.kt
@@ -35,6 +35,8 @@ class ConfigurationBuilder {
     private var generateDsl: Boolean = true
     private var generateEnums: Boolean = true
     private var generateInterfaces: Boolean = true
+    private var submodelOnly: Boolean = false
+    private var featureName: String? = null
 
     /**
      * Sets the URL or path to the WoT Thing Model to process.
@@ -117,6 +119,22 @@ class ConfigurationBuilder {
     }
 
     /**
+     * Sets whether to generate a standalone submodel package instead of a full device model.
+     */
+    fun submodelOnly(generateStandaloneSubmodel: Boolean): ConfigurationBuilder {
+        this.submodelOnly = generateStandaloneSubmodel
+        return this
+    }
+
+    /**
+     * Sets the feature name (JSON key) used in submodel-only generation.
+     */
+    fun featureName(featureName: String?): ConfigurationBuilder {
+        this.featureName = featureName
+        return this
+    }
+
+    /**
      * Applies a minimal configuration suitable for simple code generation.
      */
     fun minimal(): ConfigurationBuilder {
@@ -166,7 +184,9 @@ class ConfigurationBuilder {
             enumGenerationStrategy = enumGenerationStrategy,
             generateDsl = generateDsl,
             generateEnums = generateEnums,
-            generateInterfaces = generateInterfaces
+            generateInterfaces = generateInterfaces,
+            submodelOnly = submodelOnly,
+            featureName = featureName
         )
     }
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/GeneratorConfiguration.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/GeneratorConfiguration.kt
@@ -47,7 +47,21 @@ data class GeneratorConfiguration(
     val generateEnums: Boolean = true,
 
     /** Whether to generate interfaces (maintains backward compatibility) */
-    val generateInterfaces: Boolean = true
+    val generateInterfaces: Boolean = true,
+
+    /**
+     * When true, generates a self-contained submodel package: feature classes, a single-feature
+     * Features container, and a device-agnostic Thing — without attributes or multi-device wrappers.
+     * Use for shared submodels referenced by multiple device types.
+     */
+    val submodelOnly: Boolean = false,
+
+    /**
+     * The feature name (JSON key) to use when generating in submodel-only mode.
+     * If not set, the name is derived from the model title in camelCase.
+     * Only used when [submodelOnly] is true.
+     */
+    val featureName: String? = null
 ) {
     /**
      * Creates a copy with updated values, useful for building configurations incrementally.
@@ -61,7 +75,9 @@ data class GeneratorConfiguration(
         generateDsl: Boolean? = null,
         generateSuspendDsl: Boolean? = null,
         generateEnums: Boolean? = null,
-        generateInterfaces: Boolean? = null
+        generateInterfaces: Boolean? = null,
+        submodelOnly: Boolean? = null,
+        featureName: String? = null
     ): GeneratorConfiguration {
         return copy(
             thingModelUrl = thingModelUrl ?: this.thingModelUrl,
@@ -72,7 +88,9 @@ data class GeneratorConfiguration(
             generateDsl = generateDsl ?: this.generateDsl,
             generateSuspendDsl = generateSuspendDsl ?: this.generateSuspendDsl,
             generateEnums = generateEnums ?: this.generateEnums,
-            generateInterfaces = generateInterfaces ?: this.generateInterfaces
+            generateInterfaces = generateInterfaces ?: this.generateInterfaces,
+            submodelOnly = submodelOnly ?: this.submodelOnly,
+            featureName = featureName ?: this.featureName
         )
     }
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/SubmodelOnlyGenerationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/SubmodelOnlyGenerationTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.common
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.kotlin.generator.plugin.ThingModelGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
+import org.eclipse.ditto.wot.model.ThingModel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SubmodelOnlyGenerationTest {
+
+    @Test
+    fun `submodel-only generation creates standalone feature package with configured feature name`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-submodel-test")
+        try {
+            val configuredFeatureName = "temp-thermostat"
+            val generatedClassName = "TempThermostat"
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Room Thermostat",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "status": {
+                          "title": "Status",
+                          "type": "object",
+                          "ditto:category": "status",
+                          "properties": {
+                            "enabled": { "type": "boolean" }
+                          }
+                        }
+                      },
+                      "actions": {
+                        "reboot": {
+                          "title": "Reboot",
+                          "input": { "type": "boolean" }
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.submodeltest"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile(),
+                    classNamingStrategy = ClassNamingStrategy.ORIGINAL_THEN_COMPOUND,
+                    submodelOnly = true,
+                    featureName = configuredFeatureName
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val thingWrapper = outputDir.resolve("$packagePath/${generatedClassName}Thing.kt")
+            val featuresWrapper = outputDir.resolve("$packagePath/features/${generatedClassName}Features.kt")
+            val categoryMarker = outputDir.resolve("$packagePath/features/StatusCategory.kt")
+            val featureClass = outputDir.resolve(
+                "$packagePath/features/$configuredFeatureName/$generatedClassName.kt"
+            )
+            val propertiesClass = outputDir.resolve(
+                "$packagePath/features/$configuredFeatureName/${generatedClassName}Properties.kt"
+            )
+            val actionClass = outputDir.resolve(
+                "$packagePath/features/$configuredFeatureName/actions/Reboot.kt"
+            )
+
+            assertTrue(Files.exists(thingWrapper), "Expected standalone Thing wrapper to be generated")
+            assertTrue(Files.exists(featuresWrapper), "Expected single-feature Features wrapper to be generated")
+            assertTrue(Files.exists(categoryMarker), "Expected category marker class to be generated")
+            assertTrue(Files.exists(featureClass), "Expected feature class to be generated")
+            assertTrue(Files.exists(propertiesClass), "Expected feature properties class to be generated")
+            assertTrue(Files.exists(actionClass), "Expected action class to be generated")
+
+            val thingWrapperContent = Files.readString(thingWrapper)
+            val featuresWrapperContent = Files.readString(featuresWrapper)
+            val featureClassContent = Files.readString(featureClass)
+            val propertiesClassContent = Files.readString(propertiesClass)
+
+            assertTrue(
+                thingWrapperContent.contains("class ${generatedClassName}Thing"),
+                "Expected standalone Thing wrapper class name"
+            )
+            assertTrue(
+                featuresWrapperContent.contains("@JsonSetter(\"$configuredFeatureName\")"),
+                "Expected Features wrapper to use configured featureName as JSON key"
+            )
+            assertTrue(
+                featuresWrapperContent.contains("override fun startPath(): String = \"features\""),
+                "Expected single-feature wrapper to expose the features path"
+            )
+            assertTrue(
+                featureClassContent.contains("const val FEATURE_NAME: String = \"$configuredFeatureName\""),
+                "Expected feature class to use configured featureName"
+            )
+            assertTrue(
+                featureClassContent.contains("override fun startPath(): String = \"$configuredFeatureName\""),
+                "Expected feature class path to use configured featureName"
+            )
+            assertTrue(
+                propertiesClassContent.contains("override fun startPath(): String = \"$configuredFeatureName\""),
+                "Expected properties wrapper path to use configured featureName"
+            )
+            assertFalse(
+                thingWrapperContent.contains("fun startPath()"),
+                "Thing wrapper intentionally mirrors full-model Thing generation and should not expose a path"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    private fun deleteRecursively(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/config/EnumGenerationConfigurationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/config/EnumGenerationConfigurationTest.kt
@@ -59,11 +59,15 @@ class EnumGenerationConfigurationTest {
             .outputPackage("org.example.generated")
             .outputDirectory("target/test-output")
             .separateEnumClasses()
+            .submodelOnly(true)
+            .featureName("smartheating-thermostat")
             .build()
 
         assertEquals(EnumGenerationStrategy.SEPARATE_CLASS, config.enumGenerationStrategy)
         assertEquals("https://example.org/thing-model.jsonld", config.thingModelUrl)
         assertEquals("org.example.generated", config.outputPackage)
+        assertTrue(config.submodelOnly)
+        assertEquals("smartheating-thermostat", config.featureName)
     }
 
     @Test
@@ -124,11 +128,15 @@ class EnumGenerationConfigurationTest {
 
         val updatedConfig = originalConfig.copyWith(
             enumGenerationStrategy = EnumGenerationStrategy.SEPARATE_CLASS,
-            generateInterfaces = false
+            generateInterfaces = false,
+            submodelOnly = true,
+            featureName = "thermostat"
         )
 
         assertEquals(EnumGenerationStrategy.SEPARATE_CLASS, updatedConfig.enumGenerationStrategy)
         assertFalse(updatedConfig.generateInterfaces)
+        assertTrue(updatedConfig.submodelOnly)
+        assertEquals("thermostat", updatedConfig.featureName)
         assertEquals(originalConfig.thingModelUrl, updatedConfig.thingModelUrl)
         assertEquals(originalConfig.outputPackage, updatedConfig.outputPackage)
     }


### PR DESCRIPTION
**Problem**

Shared WoT submodels referenced by multiple device types had no way to be generated as a standalone reusable package — they were always regenerated inline inside each device model's  package.

 Additionally, the feature name used for @JsonSetter and FEATURE_NAME was always derived from the model title in camelCase, which breaks serialization when the actual Ditto JSON key is  hyphenated (e.g. "smartheating thermostat").

  **Solution**

Added submodelOnly mode that generates a self-contained package for a shared submodel, and a featureName parameter to explicitly set the JSON key used in the generated feature class.
