### PR TITLE
Generate DEFAULT_* constants from WoT Thing Model default values

### DIFF
--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
@@ -264,6 +264,10 @@ object ClassGenerator {
 
             val hasStartPathMethod = existingCompanion.funSpecs.any { it.name == "startPath" }
 
+            if (hasHasPathInterface && hasStartPathMethod && defaultConstants.isEmpty()) {
+                return
+            }
+
             val modifiedCompanion = existingCompanion.toBuilder()
             if (!hasHasPathInterface) {
                 modifiedCompanion.addSuperinterface(ClassName(Const.COMMON_PACKAGE_PATH, "HasPath"))
@@ -272,7 +276,7 @@ object ClassGenerator {
                 modifiedCompanion.addFunction(pathFunSpec)
             }
 
-            addDefaultConstantsToCompanion(modifiedCompanion, defaultConstants, existingCompanion.propertySpecs)
+            addDefaultsToCompanion(modifiedCompanion, defaultConstants, existingCompanion.propertySpecs)
 
             typeSpecBuilder.typeSpecs.remove(existingCompanion)
             typeSpecBuilder.addType(modifiedCompanion.build())
@@ -281,7 +285,7 @@ object ClassGenerator {
                 .addSuperinterface(ClassName(Const.COMMON_PACKAGE_PATH, "HasPath"))
                 .addFunction(pathFunSpec)
 
-            addDefaultConstantsToCompanion(companionBuilder, defaultConstants)
+            addDefaultsToCompanion(companionBuilder, defaultConstants)
 
             typeSpecBuilder.addType(companionBuilder.build())
         }
@@ -296,7 +300,7 @@ object ClassGenerator {
      * @param companionBuilder The companion object builder to add constants to
      * @param defaultConstants List of PropertySpec for DEFAULT_* constants
      */
-    fun addDefaultConstantsToCompanion(
+    fun addDefaultsToCompanion(
         companionBuilder: TypeSpec.Builder,
         defaultConstants: List<PropertySpec>,
         existingProperties: List<PropertySpec> = emptyList()
@@ -666,7 +670,6 @@ object ClassGenerator {
         }
 
         val defaultConstants = defaultValueExtractor.extractDefaultConstantsFromFields(schemaMap, packageName)
-            .map { it.propertySpec }
 
         val typeSpecBuilder = TypeSpec.classBuilder(className)
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
@@ -1513,7 +1516,6 @@ object ClassGenerator {
 
         val propertiesMap = properties.associate { it.first.propertyName to it.first }
         val defaultConstants = defaultValueExtractor.extractDefaultConstants(propertiesMap, packageName)
-            .map { it.propertySpec }
 
         val typeSpec = typeSpecBuilder
             .addAnnotation(buildJsonIgnoreAnnotationSpec())

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
@@ -300,17 +300,14 @@ object ClassGenerator {
      * @param companionBuilder The companion object builder to add constants to
      * @param defaultConstants List of PropertySpec for DEFAULT_* constants
      */
-    fun addDefaultsToCompanion(
+    internal fun addDefaultsToCompanion(
         companionBuilder: TypeSpec.Builder,
         defaultConstants: List<PropertySpec>,
         existingProperties: List<PropertySpec> = emptyList()
     ) {
-        defaultConstants.forEach { constant ->
-            val alreadyExists = existingProperties.any { it.name == constant.name }
-            if (!alreadyExists) {
-                companionBuilder.addProperty(constant)
-            }
-        }
+        defaultConstants
+            .filter { constant -> existingProperties.none { it.name == constant.name } }
+            .forEach { companionBuilder.addProperty(it) }
     }
 
     private fun createFileSpecBuilder(
@@ -669,8 +666,6 @@ object ClassGenerator {
             emptyList()
         }
 
-        val defaultConstants = defaultValueExtractor.extractDefaultConstantsFromFields(schemaMap, packageName)
-
         val typeSpecBuilder = TypeSpec.classBuilder(className)
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
             .addAnnotation(buildJsonIncludeAnnotationSpec())
@@ -705,7 +700,7 @@ object ClassGenerator {
                 )
             ),
             originalName = propertyName,
-            defaultConstants = defaultConstants
+            defaultConstants = defaultValueExtractor.extractDefaultConstants(schemaMap, packageName)
         )
     }
 
@@ -1515,7 +1510,6 @@ object ClassGenerator {
         )
 
         val propertiesMap = properties.associate { it.first.propertyName to it.first }
-        val defaultConstants = defaultValueExtractor.extractDefaultConstants(propertiesMap, packageName)
 
         val typeSpec = typeSpecBuilder
             .addAnnotation(buildJsonIgnoreAnnotationSpec())
@@ -1528,7 +1522,7 @@ object ClassGenerator {
             listOf(dslGenerator.generateFeatureDslFunSpec(className, packageName, true)),
             emptyList(),
             null,
-            defaultConstants
+            defaultValueExtractor.extractDefaultConstants(propertiesMap, packageName)
         )
     }
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
@@ -700,7 +700,9 @@ object ClassGenerator {
                 )
             ),
             originalName = propertyName,
-            defaultConstants = defaultValueExtractor.extractDefaultConstants(schemaMap, packageName)
+            defaultConstants = defaultValueExtractor.extractDefaultConstants(
+                schemaMap, packageName, updatedFields.associate { it.first to it.second.type }
+            )
         )
     }
 
@@ -1503,13 +1505,14 @@ object ClassGenerator {
                 })
         }
 
-        addInlineEnumsToTypeSpec(
+        val updatedProperties = addInlineEnumsToTypeSpec(
             properties.map { it.first.propertyName to it.second }.toMutableList(),
             typeSpecBuilder,
             packageName
         )
 
         val propertiesMap = properties.associate { it.first.propertyName to it.first }
+        val resolvedTypes = updatedProperties.associate { it.first to it.second.type }
 
         val typeSpec = typeSpecBuilder
             .addAnnotation(buildJsonIgnoreAnnotationSpec())
@@ -1522,7 +1525,7 @@ object ClassGenerator {
             listOf(dslGenerator.generateFeatureDslFunSpec(className, packageName, true)),
             emptyList(),
             null,
-            defaultValueExtractor.extractDefaultConstants(propertiesMap, packageName)
+            defaultValueExtractor.extractDefaultConstants(propertiesMap, packageName, resolvedTypes)
         )
     }
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
@@ -62,6 +62,7 @@ object ClassGenerator {
     private val dslGenerator = DslGenerator
     private val enumGenerator = EnumGenerator
     private val schemaTypeResolver = SchemaTypeResolver
+    private val defaultValueExtractor = DefaultValueExtractor
 
     private var outputDir: String = ""
     private var enumGenerationStrategy: IEnumGenerationStrategy? = null
@@ -175,6 +176,7 @@ object ClassGenerator {
      * @param funSpecs Additional functions to add to the file
      * @param imports Additional imports to add to the file
      * @param originalName The original name for path generation
+     * @param defaultConstants Optional list of DEFAULT_* property specs for companion object
      */
     fun generateNewClass(
         typeSpec: TypeSpec,
@@ -182,7 +184,8 @@ object ClassGenerator {
         packageName: String,
         funSpecs: List<FunSpec> = emptyList(),
         imports: List<String> = emptyList(),
-        originalName: String? = null
+        originalName: String? = null,
+        defaultConstants: List<PropertySpec> = emptyList()
     ) {
         logger.debug("Generating class $className in package $packageName ...")
         val isPropertiesClass = typeSpec.superinterfaces.keys.any {
@@ -193,7 +196,7 @@ object ClassGenerator {
 
         val newTypeSpecBuilder = typeSpec.toBuilder()
 
-        mergeOrAddCompanionObject(newTypeSpecBuilder, pathFunSpec)
+        mergeOrAddCompanionObject(newTypeSpecBuilder, pathFunSpec, defaultConstants)
 
         val fileSpecBuilder = createFileSpecBuilder(newTypeSpecBuilder, className, packageName, funSpecs, imports)
 
@@ -230,6 +233,28 @@ object ClassGenerator {
      * @param pathFunSpec The path function specification to add
      */
     fun mergeOrAddCompanionObject(typeSpecBuilder: TypeSpec.Builder, pathFunSpec: FunSpec) {
+        mergeOrAddCompanionObject(typeSpecBuilder, pathFunSpec, emptyList())
+    }
+
+    /**
+     * Merges or adds a companion object with path functionality and default constants.
+     *
+     * If a companion object already exists, it adds the path function and default constants to it.
+     * Otherwise, it creates a new companion object with both.
+     *
+     * This overload supports adding DEFAULT_* constants extracted from WoT Thing Model
+     * schema default values. The constants are placed on the companion object of the
+     * class that directly owns the property.
+     *
+     * @param typeSpecBuilder The type spec builder to modify
+     * @param pathFunSpec The path function specification to add
+     * @param defaultConstants List of PropertySpec for DEFAULT_* constants to add
+     */
+    fun mergeOrAddCompanionObject(
+        typeSpecBuilder: TypeSpec.Builder,
+        pathFunSpec: FunSpec,
+        defaultConstants: List<PropertySpec>
+    ) {
         val existingCompanion = typeSpecBuilder.build().typeSpecs.find { it.isCompanion }
 
         if (existingCompanion != null) {
@@ -239,10 +264,6 @@ object ClassGenerator {
 
             val hasStartPathMethod = existingCompanion.funSpecs.any { it.name == "startPath" }
 
-            if (hasHasPathInterface && hasStartPathMethod) {
-                return
-            }
-
             val modifiedCompanion = existingCompanion.toBuilder()
             if (!hasHasPathInterface) {
                 modifiedCompanion.addSuperinterface(ClassName(Const.COMMON_PACKAGE_PATH, "HasPath"))
@@ -251,14 +272,40 @@ object ClassGenerator {
                 modifiedCompanion.addFunction(pathFunSpec)
             }
 
+            addDefaultConstantsToCompanion(modifiedCompanion, defaultConstants, existingCompanion.propertySpecs)
+
             typeSpecBuilder.typeSpecs.remove(existingCompanion)
             typeSpecBuilder.addType(modifiedCompanion.build())
         } else {
-            val companionObjectSpec = TypeSpec.companionObjectBuilder()
+            val companionBuilder = TypeSpec.companionObjectBuilder()
                 .addSuperinterface(ClassName(Const.COMMON_PACKAGE_PATH, "HasPath"))
                 .addFunction(pathFunSpec)
-                .build()
-            typeSpecBuilder.addType(companionObjectSpec)
+
+            addDefaultConstantsToCompanion(companionBuilder, defaultConstants)
+
+            typeSpecBuilder.addType(companionBuilder.build())
+        }
+    }
+
+    /**
+     * Adds default constants to an existing companion object builder.
+     *
+     * This method is used when building category inner classes or nested object classes
+     * that need their own DEFAULT_* constants.
+     *
+     * @param companionBuilder The companion object builder to add constants to
+     * @param defaultConstants List of PropertySpec for DEFAULT_* constants
+     */
+    fun addDefaultConstantsToCompanion(
+        companionBuilder: TypeSpec.Builder,
+        defaultConstants: List<PropertySpec>,
+        existingProperties: List<PropertySpec> = emptyList()
+    ) {
+        defaultConstants.forEach { constant ->
+            val alreadyExists = existingProperties.any { it.name == constant.name }
+            if (!alreadyExists) {
+                companionBuilder.addProperty(constant)
+            }
         }
     }
 
@@ -600,8 +647,8 @@ object ClassGenerator {
         if (propertiesJson == null || propertiesJson.isEmpty()) {
             logger.warn("No properties found for class $className, schema: ${targetObjectSchema.toJson()}")
         }
+        val schemaMap = mutableMapOf<String, SingleDataSchema>()
         val fields = if (propertiesJson != null) {
-            val schemaMap = mutableMapOf<String, SingleDataSchema>()
             for (entry in propertiesJson) {
                 val key = entry.key.toString()
                 val value = entry.value
@@ -617,6 +664,9 @@ object ClassGenerator {
         } else {
             emptyList()
         }
+
+        val defaultConstants = defaultValueExtractor.extractDefaultConstantsFromFields(schemaMap, packageName)
+            .map { it.propertySpec }
 
         val typeSpecBuilder = TypeSpec.classBuilder(className)
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
@@ -651,7 +701,8 @@ object ClassGenerator {
                     extractDeprecationNotice(targetObjectSchema)
                 )
             ),
-            originalName = propertyName
+            originalName = propertyName,
+            defaultConstants = defaultConstants
         )
     }
 
@@ -1460,6 +1511,10 @@ object ClassGenerator {
             packageName
         )
 
+        val propertiesMap = properties.associate { it.first.propertyName to it.first }
+        val defaultConstants = defaultValueExtractor.extractDefaultConstants(propertiesMap, packageName)
+            .map { it.propertySpec }
+
         val typeSpec = typeSpecBuilder
             .addAnnotation(buildJsonIgnoreAnnotationSpec())
             .addFunctions(attributesDslFunsSpecs)
@@ -1468,7 +1523,10 @@ object ClassGenerator {
             typeSpec,
             className,
             packageName,
-            listOf(dslGenerator.generateFeatureDslFunSpec(className, packageName, true))
+            listOf(dslGenerator.generateFeatureDslFunSpec(className, packageName, true)),
+            emptyList(),
+            null,
+            defaultConstants
         )
     }
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractor.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractor.kt
@@ -19,6 +19,7 @@ import com.squareup.kotlinpoet.DOUBLE
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.STRING
@@ -41,10 +42,11 @@ object DefaultValueExtractor {
     /** Extracts DEFAULT_* constants from a map of schema fields (or properties). */
     fun extractDefaultConstants(
         fields: Map<String, SingleDataSchema>,
-        packageName: String
+        packageName: String,
+        resolvedTypes: Map<String, TypeName> = emptyMap()
     ): List<PropertySpec> {
         return fields.mapNotNull { (name, schema) ->
-            extractDefaultFromSchema(name, schema, packageName)
+            extractDefaultFromSchema(name, schema, packageName, resolvedTypes)
         }
     }
 
@@ -52,7 +54,8 @@ object DefaultValueExtractor {
     internal fun extractDefaultFromSchema(
         fieldName: String,
         schema: SingleDataSchema,
-        packageName: String
+        packageName: String,
+        resolvedTypes: Map<String, TypeName> = emptyMap()
     ): PropertySpec? {
         val defaultValue = schema.default.orElse(null) ?: return null
         val schemaType = schema.type.orElse(null) ?: return null
@@ -71,8 +74,8 @@ object DefaultValueExtractor {
 
             DataSchemaType.STRING -> when {
                 isStringEnum(schema) -> {
-                    val enumName = asClassName(fieldName)
-                    createEnumDefault(constantName, ClassName("", enumName), defaultValue.asString(), enumName)
+                    val enumType = resolveEnumType(fieldName, resolvedTypes)
+                    createEnumDefault(constantName, enumType, defaultValue.asString(), enumType.simpleName)
                 }
                 isDateTimeFormat(schema) ->
                     createInstantDefault(constantName, defaultValue.asString())
@@ -91,7 +94,8 @@ object DefaultValueExtractor {
                         logger.warn("Object enum default for '$fieldName' is missing 'name' field, skipping")
                         return null
                     }
-                    createObjectEnumDefault(constantName, ClassName("", asClassName(fieldName)), asValidEnumConstant(nameField.asString()))
+                    val sealedType = resolveEnumType(fieldName, resolvedTypes)
+                    createObjectEnumDefault(constantName, sealedType, asValidEnumConstant(nameField.asString()))
                 } else {
                     null
                 }
@@ -100,7 +104,7 @@ object DefaultValueExtractor {
             DataSchemaType.ARRAY -> {
                 if (!defaultValue.isArray) return null
                 val defaultArray = defaultValue.asArray()
-                val elementType = resolveArrayElementType(schema, packageName, fieldName)
+                val elementType = resolveArrayElementType(schema, packageName, fieldName, resolvedTypes)
                 if (defaultArray.isEmpty) {
                     createEmptyListDefault(constantName, elementType)
                 } else {
@@ -116,7 +120,23 @@ object DefaultValueExtractor {
         }
     }
 
-    private fun resolveArrayElementType(schema: SingleDataSchema, packageName: String, fieldName: String): TypeName {
+    /** Resolves the enum ClassName from resolved types, falling back to unqualified name. */
+    private fun resolveEnumType(fieldName: String, resolvedTypes: Map<String, TypeName>): ClassName {
+        val resolved = resolvedTypes[fieldName]?.copy(nullable = false)
+        if (resolved is ClassName) return resolved
+        return ClassName("", asClassName(fieldName))
+    }
+
+    private fun resolveArrayElementType(
+        schema: SingleDataSchema,
+        packageName: String,
+        fieldName: String,
+        resolvedTypes: Map<String, TypeName> = emptyMap()
+    ): TypeName {
+        val resolvedListType = resolvedTypes[fieldName]?.copy(nullable = false) as? ParameterizedTypeName
+        val resolvedElementType = resolvedListType?.typeArguments?.firstOrNull()?.copy(nullable = false)
+        if (resolvedElementType != null) return resolvedElementType
+
         val itemsJson = schema.toJson().getValue("items").orElse(null)?.asObject() ?: run {
             logger.warn("Missing array items schema for '$fieldName', defaulting to String")
             return STRING

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractor.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractor.kt
@@ -1,0 +1,527 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.util
+
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.TypeName
+import org.eclipse.ditto.json.JsonArray
+import org.eclipse.ditto.wot.model.DataSchemaType
+import org.eclipse.ditto.wot.model.Property
+import org.eclipse.ditto.wot.model.SingleDataSchema
+import org.slf4j.LoggerFactory
+
+/**
+ * Extracts default values from WoT Thing Model schemas and generates
+ * corresponding Kotlin constants for companion objects.
+ *
+ * This object handles the extraction of `"default"` values from JSON-LD schemas
+ * and generates `DEFAULT_<NAME>` companion object constants with appropriate types:
+ * - Boolean defaults: `const val DEFAULT_<NAME>: Boolean = <value>`
+ * - Integer defaults: `const val DEFAULT_<NAME>: Long = <value>`
+ * - Number defaults: `const val DEFAULT_<NAME>: Double = <value>`
+ * - String defaults: `const val DEFAULT_<NAME>: String = "<value>"`
+ * - DateTime defaults: `val DEFAULT_<NAME>: Instant = Instant.parse("<value>")`
+ * - Enum defaults: `val DEFAULT_<NAME>: EnumType = EnumType.CONSTANT`
+ * - Object enum (sealed class) defaults: `val DEFAULT_<NAME>: SealedType = SealedType.INSTANCE`
+ * - Empty array defaults: `val DEFAULT_<NAME>: List<T> = emptyList()`
+ *
+ * @since 1.0.0
+ */
+object DefaultValueExtractor {
+
+    private val logger = LoggerFactory.getLogger(DefaultValueExtractor::class.java)
+
+    /**
+     * Represents an extracted default value with its corresponding property specification.
+     *
+     * @property propertySpec The KotlinPoet PropertySpec for the default constant
+     */
+    data class ExtractedDefault(
+        val propertySpec: PropertySpec
+    )
+
+    /**
+     * Extracts default value constants from a collection of properties.
+     *
+     * Processes each property in the map and extracts any defined default values,
+     * generating appropriate constant definitions for companion objects.
+     *
+     * @param properties Map of property names to their Property definitions
+     * @param packageName The package name for type resolution
+     * @return List of extracted default constants, empty if no defaults found
+     */
+    fun extractDefaultConstants(
+        properties: Map<String, Property>,
+        packageName: String
+    ): List<ExtractedDefault> {
+        return properties.mapNotNull { (name, property) ->
+            extractDefaultFromProperty(name, property, packageName)
+        }
+    }
+
+    /**
+     * Extracts default value constants from a collection of schema fields.
+     *
+     * Processes each field in the map and extracts any defined default values,
+     * generating appropriate constant definitions for companion objects.
+     *
+     * @param fields Map of field names to their SingleDataSchema definitions
+     * @param packageName The package name for type resolution
+     * @return List of extracted default constants, empty if no defaults found
+     */
+    fun extractDefaultConstantsFromFields(
+        fields: Map<String, SingleDataSchema>,
+        packageName: String
+    ): List<ExtractedDefault> {
+        return fields.mapNotNull { (name, schema) ->
+            extractDefaultFromSchema(name, schema, packageName)
+        }
+    }
+
+    /**
+     * Extracts a default constant from a single property.
+     *
+     * Analyzes the property schema to determine the type and default value,
+     * then generates the appropriate constant specification.
+     *
+     * @param propertyName The original property name (will be converted to SCREAMING_SNAKE_CASE)
+     * @param property The Property definition containing the schema
+     * @param packageName The package name for type resolution
+     * @return The extracted default, or null if no default is defined or type is unsupported
+     */
+    private fun extractDefaultFromProperty(
+        propertyName: String,
+        property: Property,
+        packageName: String
+    ): ExtractedDefault? {
+        // Property extends SingleDataSchema, so we can treat it as a schema
+        return extractDefaultFromSchema(propertyName, property, packageName)
+    }
+
+    /**
+     * Extracts a default constant from a single schema field.
+     *
+     * Analyzes the schema to determine the type and default value,
+     * then generates the appropriate constant specification.
+     *
+     * @param fieldName The original field name (will be converted to SCREAMING_SNAKE_CASE)
+     * @param schema The SingleDataSchema definition
+     * @param packageName The package name for type resolution
+     * @return The extracted default, or null if no default is defined or type is unsupported
+     */
+    fun extractDefaultFromSchema(
+        fieldName: String,
+        schema: SingleDataSchema,
+        packageName: String
+    ): ExtractedDefault? {
+        val defaultValue = schema.default.orElse(null) ?: return null
+        val schemaType = schema.type.orElse(null) ?: return null
+
+        return when (schemaType) {
+            DataSchemaType.BOOLEAN -> {
+                val value = defaultValue.asBoolean()
+                val propSpec = createBooleanDefault(asScreamingSnakeCase(fieldName), value)
+                ExtractedDefault(propSpec)
+            }
+
+            DataSchemaType.INTEGER -> {
+                val value = defaultValue.asLong()
+                val propSpec = createIntegerDefault(asScreamingSnakeCase(fieldName), value)
+                ExtractedDefault(propSpec)
+            }
+
+            DataSchemaType.NUMBER -> {
+                val value = defaultValue.asDouble()
+                val propSpec = createNumberDefault(asScreamingSnakeCase(fieldName), value)
+                ExtractedDefault(propSpec)
+            }
+
+            DataSchemaType.STRING -> {
+                // Check if it's an enum
+                if (isStringEnum(schema)) {
+                    val enumName = asClassName(fieldName)
+                    val enumTypeName = ClassName("", enumName)
+                    val enumConstantValue = defaultValue.asString()
+                    val propSpec = createEnumDefault(asScreamingSnakeCase(fieldName), enumTypeName, enumConstantValue, enumName)
+                    ExtractedDefault(propSpec)
+                }
+                // Check if it's a date-time format
+                else if (isDateTimeFormat(schema)) {
+                    val value = defaultValue.asString()
+                    val propSpec = createInstantDefault(asScreamingSnakeCase(fieldName), value)
+                    ExtractedDefault(propSpec)
+                }
+                // Plain string
+                else {
+                    val value = defaultValue.asString()
+                    val propSpec = createStringDefault(asScreamingSnakeCase(fieldName), value)
+                    ExtractedDefault(propSpec)
+                }
+            }
+
+            DataSchemaType.OBJECT -> {
+                // Check if it's an object enum (sealed class)
+                if (isObjectEnum(schema)) {
+                    // Default must be an object with a "name" field
+                    if (!defaultValue.isObject) {
+                        logger.warn("Object enum default for '$fieldName' is not an object, skipping")
+                        return null
+                    }
+                    val defaultObj = defaultValue.asObject()
+                    val nameField = defaultObj.getValue("name").orElse(null)
+                    if (nameField == null || !nameField.isString) {
+                        logger.warn("Object enum default for '$fieldName' is missing 'name' field, skipping")
+                        return null
+                    }
+                    val nameValue = nameField.asString()
+                    val sealedTypeName = ClassName("", asClassName(fieldName))
+                    val objectInstanceName = asValidEnumConstant(nameValue)
+                    val propSpec = createObjectEnumDefault(asScreamingSnakeCase(fieldName), sealedTypeName, objectInstanceName)
+                    ExtractedDefault(propSpec)
+                } else {
+                    // EDGE-2: Nested object defaults - skip silently
+                    null
+                }
+            }
+
+            DataSchemaType.ARRAY -> {
+                if (!defaultValue.isArray) {
+                    return null
+                }
+                val defaultArray = defaultValue.asArray()
+                val elementType = resolveArrayElementType(schema, packageName, fieldName)
+                if (defaultArray.isEmpty) {
+                    val propSpec = createEmptyListDefault(asScreamingSnakeCase(fieldName), elementType)
+                    ExtractedDefault(propSpec)
+                } else {
+                    val itemsEnum = resolveArrayItemsEnum(schema)
+                    val propSpec = createListDefault(asScreamingSnakeCase(fieldName), elementType, defaultArray, itemsEnum, fieldName)
+                    if (propSpec != null) {
+                        ExtractedDefault(propSpec)
+                    } else {
+                        logger.warn("Non-empty array default for '$fieldName' contains unsupported element type, skipping")
+                        null
+                    }
+                }
+            }
+
+            DataSchemaType.NULL -> null
+        }
+    }
+
+    /**
+     * Resolves the element type for an array schema.
+     */
+    private fun resolveArrayElementType(schema: SingleDataSchema, packageName: String, fieldName: String): TypeName {
+        val schemaJson = schema.toJson()
+        val itemsValue = schemaJson.getValue("items").orElse(null)
+        if (itemsValue != null && itemsValue.isObject) {
+            val itemsJson = itemsValue.asObject()
+            val itemType = itemsJson.getValue("type").orElse(null)
+            if (itemType != null && itemType.isString) {
+                return when (itemType.asString()) {
+                    "boolean" -> BOOLEAN
+                    "integer" -> LONG
+                    "number" -> DOUBLE
+                    "string" -> {
+                        val hasEnum = itemsJson.getValue("enum").orElse(null)
+                        if (hasEnum != null && hasEnum.isArray && !hasEnum.asArray().isEmpty) {
+                            ClassName("", asClassName(fieldName) + "Item")
+                        } else {
+                            STRING
+                        }
+                    }
+                    "object" -> ClassName(packageName, asClassName(fieldName) + "Item")
+                    else -> STRING
+                }
+            }
+        }
+        return STRING
+    }
+
+    /**
+     * Creates a PropertySpec for a boolean default constant.
+     *
+     * Generates: `const val DEFAULT_<NAME>: Boolean = <value>`
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param value The boolean default value
+     * @return PropertySpec for the constant
+     */
+    internal fun createBooleanDefault(
+        constantName: String,
+        value: Boolean
+    ): PropertySpec {
+        return PropertySpec.builder("DEFAULT_$constantName", BOOLEAN)
+            .addModifiers(KModifier.CONST)
+            .initializer("%L", value)
+            .build()
+    }
+
+    /**
+     * Creates a PropertySpec for an integer (Long) default constant.
+     *
+     * Generates: `const val DEFAULT_<NAME>: Long = <value>`
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param value The Long default value
+     * @return PropertySpec for the constant
+     */
+    internal fun createIntegerDefault(
+        constantName: String,
+        value: Long
+    ): PropertySpec {
+        return PropertySpec.builder("DEFAULT_$constantName", LONG)
+            .addModifiers(KModifier.CONST)
+            .initializer("%L", value)
+            .build()
+    }
+
+    /**
+     * Creates a PropertySpec for a number (Double) default constant.
+     *
+     * Generates: `const val DEFAULT_<NAME>: Double = <value>`
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param value The Double default value
+     * @return PropertySpec for the constant
+     */
+    internal fun createNumberDefault(
+        constantName: String,
+        value: Double
+    ): PropertySpec {
+        return PropertySpec.builder("DEFAULT_$constantName", DOUBLE)
+            .addModifiers(KModifier.CONST)
+            .initializer("%L", value)
+            .build()
+    }
+
+    /**
+     * Creates a PropertySpec for a plain string default constant.
+     *
+     * Generates: `const val DEFAULT_<NAME>: String = "<value>"`
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param value The String default value
+     * @return PropertySpec for the constant
+     */
+    internal fun createStringDefault(
+        constantName: String,
+        value: String
+    ): PropertySpec {
+        return PropertySpec.builder("DEFAULT_$constantName", STRING)
+            .addModifiers(KModifier.CONST)
+            .initializer("%S", value)
+            .build()
+    }
+
+    /**
+     * Creates a PropertySpec for a date-time (Instant) default constant.
+     *
+     * Generates: `val DEFAULT_<NAME>: Instant = Instant.parse("<value>")`
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param value The ISO-8601 date-time string
+     * @return PropertySpec for the constant
+     */
+    internal fun createInstantDefault(
+        constantName: String,
+        value: String
+    ): PropertySpec {
+        val instantType = ClassName("java.time", "Instant")
+        return PropertySpec.builder("DEFAULT_$constantName", instantType)
+            .initializer("%T.parse(%S)", instantType, value)
+            .build()
+    }
+
+    /**
+     * Creates a PropertySpec for a string enum default constant.
+     *
+     * Generates: `val DEFAULT_<NAME>: EnumType = EnumType.CONSTANT`
+     * Uses `asEnumConstantName()` to convert the default value to enum constant format.
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param enumTypeName The ClassName of the enum type (unqualified for inline enums)
+     * @param enumConstantValue The raw enum constant value from the schema default
+     * @param enumName The name of the enum class (for asEnumConstantName conversion)
+     * @return PropertySpec for the constant
+     */
+    internal fun createEnumDefault(
+        constantName: String,
+        enumTypeName: ClassName,
+        enumConstantValue: String,
+        enumName: String
+    ): PropertySpec {
+        val convertedConstant = asEnumConstantName(enumName, enumConstantValue)
+        return PropertySpec.builder("DEFAULT_$constantName", enumTypeName)
+            .initializer("%T.%L", enumTypeName, convertedConstant)
+            .build()
+    }
+
+    /**
+     * Creates a PropertySpec for an object enum (sealed class) default constant.
+     *
+     * Generates: `val DEFAULT_<NAME>: SealedType = SealedType.INSTANCE`
+     * Extracts the `"name"` field from the JSON object default and uses
+     * `asValidEnumConstant()` to convert to object name format.
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param sealedTypeName The ClassName of the sealed class type (unqualified for inline)
+     * @param objectInstanceName The name of the sealed class object instance
+     * @return PropertySpec for the constant
+     */
+    internal fun createObjectEnumDefault(
+        constantName: String,
+        sealedTypeName: ClassName,
+        objectInstanceName: String
+    ): PropertySpec {
+        return PropertySpec.builder("DEFAULT_$constantName", sealedTypeName)
+            .initializer("%T.%L", sealedTypeName, objectInstanceName)
+            .build()
+    }
+
+    /**
+     * Creates a PropertySpec for an empty list default constant.
+     *
+     * Generates: `val DEFAULT_<NAME>: List<T> = emptyList()`
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param elementType The type of elements in the list
+     * @return PropertySpec for the constant
+     */
+    internal fun createEmptyListDefault(
+        constantName: String,
+        elementType: TypeName
+    ): PropertySpec {
+        val listType = LIST.parameterizedBy(elementType)
+        return PropertySpec.builder("DEFAULT_$constantName", listType)
+            .initializer("emptyList()")
+            .build()
+    }
+
+    /**
+     * Creates a PropertySpec for a non-empty list default constant.
+     *
+     * Supports primitive element types (Boolean, Long, Double, String) and string enums.
+     *
+     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
+     * @param elementType The type of elements in the list
+     * @param defaultArray The JSON array containing the default values
+     * @param itemsEnum The enum values from the items schema, or null if not an enum array
+     * @param fieldName The original field name (for enum name resolution)
+     * @return PropertySpec for the constant, or null if the element type is unsupported
+     */
+    internal fun createListDefault(
+        constantName: String,
+        elementType: TypeName,
+        defaultArray: JsonArray,
+        itemsEnum: List<String>?,
+        fieldName: String
+    ): PropertySpec? {
+        val elements = mutableListOf<CodeBlock>()
+
+        for (value in defaultArray) {
+            val element = when (elementType) {
+                BOOLEAN -> CodeBlock.of("%L", value.asBoolean())
+                LONG -> CodeBlock.of("%L", value.asLong())
+                DOUBLE -> CodeBlock.of("%L", value.asDouble())
+                STRING -> CodeBlock.of("%S", value.asString())
+                else -> {
+                    // Check if it's an enum type
+                    if (itemsEnum != null && value.isString && elementType is ClassName) {
+                        val enumName = elementType.simpleName
+                        val convertedConstant = asEnumConstantName(enumName, value.asString())
+                        CodeBlock.of("%T.%L", elementType, convertedConstant)
+                    } else {
+                        return null
+                    }
+                }
+            }
+            elements.add(element)
+        }
+
+        val listType = LIST.parameterizedBy(elementType)
+        val initializer = CodeBlock.builder()
+            .add("listOf(")
+            .add(elements.joinToString(", ") { it.toString() })
+            .add(")")
+            .build()
+        return PropertySpec.builder("DEFAULT_$constantName", listType)
+            .initializer(initializer)
+            .build()
+    }
+
+    /**
+     * Resolves enum values from the items schema of an array, if present.
+     *
+     * @param schema The array schema
+     * @return List of enum string values, or null if items is not a string enum
+     */
+    private fun resolveArrayItemsEnum(schema: SingleDataSchema): List<String>? {
+        val schemaJson = schema.toJson()
+        val itemsValue = schemaJson.getValue("items").orElse(null) ?: return null
+        if (!itemsValue.isObject) return null
+        val itemsJson = itemsValue.asObject()
+        val itemType = itemsJson.getValue("type").orElse(null)
+        if (itemType == null || !itemType.isString || itemType.asString() != "string") return null
+        val enumArray = itemsJson.getValue("enum").orElse(null) ?: return null
+        if (!enumArray.isArray) return null
+        return enumArray.asArray().map { it.asString() }
+    }
+
+    /**
+     * Determines if a schema represents a string enum.
+     *
+     * @param schema The SingleDataSchema to check
+     * @return true if this is a string type with enum values
+     */
+    internal fun isStringEnum(schema: SingleDataSchema): Boolean {
+        val schemaType = schema.type.orElse(null) ?: return false
+        if (schemaType != DataSchemaType.STRING) return false
+        return schema.enum.isNotEmpty()
+    }
+
+    /**
+     * Determines if a schema represents an object enum (sealed class).
+     *
+     * @param schema The SingleDataSchema to check
+     * @return true if this is an object type with enum values
+     */
+    internal fun isObjectEnum(schema: SingleDataSchema): Boolean {
+        val schemaType = schema.type.orElse(null) ?: return false
+        if (schemaType != DataSchemaType.OBJECT) return false
+        return schema.enum.isNotEmpty()
+    }
+
+    /**
+     * Determines if a schema has a date-time format.
+     *
+     * @param schema The SingleDataSchema to check
+     * @return true if this is a string type with format "date-time"
+     */
+    internal fun isDateTimeFormat(schema: SingleDataSchema): Boolean {
+        val schemaType = schema.type.orElse(null) ?: return false
+        if (schemaType != DataSchemaType.STRING) return false
+        val format = schema.format.orElse(null) ?: return false
+        return format.equals("date-time", ignoreCase = true)
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractor.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,61 +25,21 @@ import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 import org.eclipse.ditto.json.JsonArray
 import org.eclipse.ditto.wot.model.DataSchemaType
-import org.eclipse.ditto.wot.model.Property
 import org.eclipse.ditto.wot.model.SingleDataSchema
 import org.slf4j.LoggerFactory
 
 /**
  * Extracts default values from WoT Thing Model schemas and generates
- * corresponding Kotlin constants for companion objects.
+ * corresponding DEFAULT_* Kotlin constants for companion objects.
  *
- * This object handles the extraction of `"default"` values from JSON-LD schemas
- * and generates `DEFAULT_<NAME>` companion object constants with appropriate types:
- * - Boolean defaults: `const val DEFAULT_<NAME>: Boolean = <value>`
- * - Integer defaults: `const val DEFAULT_<NAME>: Long = <value>`
- * - Number defaults: `const val DEFAULT_<NAME>: Double = <value>`
- * - String defaults: `const val DEFAULT_<NAME>: String = "<value>"`
- * - DateTime defaults: `val DEFAULT_<NAME>: Instant = Instant.parse("<value>")`
- * - Enum defaults: `val DEFAULT_<NAME>: EnumType = EnumType.CONSTANT`
- * - Object enum (sealed class) defaults: `val DEFAULT_<NAME>: SealedType = SealedType.INSTANCE`
- * - Empty array defaults: `val DEFAULT_<NAME>: List<T> = emptyList()`
- *
- * @since 1.0.0
+ * Handles all WoT data types including primitives, enums, date-time, and arrays.
  */
 object DefaultValueExtractor {
 
     private val logger = LoggerFactory.getLogger(DefaultValueExtractor::class.java)
 
-    /**
-     * Extracts default value constants from a collection of properties.
-     *
-     * Processes each property in the map and extracts any defined default values,
-     * generating appropriate constant definitions for companion objects.
-     *
-     * @param properties Map of property names to their Property definitions
-     * @param packageName The package name for type resolution
-     * @return List of PropertySpec for DEFAULT_* constants, empty if no defaults found
-     */
+    /** Extracts DEFAULT_* constants from a map of schema fields (or properties). */
     fun extractDefaultConstants(
-        properties: Map<String, Property>,
-        packageName: String
-    ): List<PropertySpec> {
-        return properties.mapNotNull { (name, property) ->
-            extractDefaultFromProperty(name, property, packageName)
-        }
-    }
-
-    /**
-     * Extracts default value constants from a collection of schema fields.
-     *
-     * Processes each field in the map and extracts any defined default values,
-     * generating appropriate constant definitions for companion objects.
-     *
-     * @param fields Map of field names to their SingleDataSchema definitions
-     * @param packageName The package name for type resolution
-     * @return List of PropertySpec for DEFAULT_* constants, empty if no defaults found
-     */
-    fun extractDefaultConstantsFromFields(
         fields: Map<String, SingleDataSchema>,
         packageName: String
     ): List<PropertySpec> {
@@ -88,37 +48,7 @@ object DefaultValueExtractor {
         }
     }
 
-    /**
-     * Extracts a default constant from a single property.
-     *
-     * Analyzes the property schema to determine the type and default value,
-     * then generates the appropriate constant specification.
-     *
-     * @param propertyName The original property name (will be converted to SCREAMING_SNAKE_CASE)
-     * @param property The Property definition containing the schema
-     * @param packageName The package name for type resolution
-     * @return The extracted default, or null if no default is defined or type is unsupported
-     */
-    private fun extractDefaultFromProperty(
-        propertyName: String,
-        property: Property,
-        packageName: String
-    ): PropertySpec? {
-        // Property extends SingleDataSchema, so we can treat it as a schema
-        return extractDefaultFromSchema(propertyName, property, packageName)
-    }
-
-    /**
-     * Extracts a default constant from a single schema field.
-     *
-     * Analyzes the schema to determine the type and default value,
-     * then generates the appropriate constant specification.
-     *
-     * @param fieldName The original field name (will be converted to SCREAMING_SNAKE_CASE)
-     * @param schema The SingleDataSchema definition
-     * @param packageName The package name for type resolution
-     * @return The extracted default, or null if no default is defined or type is unsupported
-     */
+    /** Extracts a default constant from a single schema field. */
     internal fun extractDefaultFromSchema(
         fieldName: String,
         schema: SingleDataSchema,
@@ -127,91 +57,58 @@ object DefaultValueExtractor {
         val defaultValue = schema.default.orElse(null) ?: return null
         val schemaType = schema.type.orElse(null) ?: return null
 
+        val constantName = asScreamingSnakeCase(fieldName)
+
         return when (schemaType) {
-            DataSchemaType.BOOLEAN -> {
-                val value = defaultValue.asBoolean()
-                val propSpec = createBooleanDefault(asScreamingSnakeCase(fieldName), value)
-                propSpec
-            }
+            DataSchemaType.BOOLEAN ->
+                createBooleanDefault(constantName, defaultValue.asBoolean())
 
-            DataSchemaType.INTEGER -> {
-                val value = defaultValue.asLong()
-                val propSpec = createIntegerDefault(asScreamingSnakeCase(fieldName), value)
-                propSpec
-            }
+            DataSchemaType.INTEGER ->
+                createIntegerDefault(constantName, defaultValue.asLong())
 
-            DataSchemaType.NUMBER -> {
-                val value = defaultValue.asDouble()
-                val propSpec = createNumberDefault(asScreamingSnakeCase(fieldName), value)
-                propSpec
-            }
+            DataSchemaType.NUMBER ->
+                createNumberDefault(constantName, defaultValue.asDouble())
 
-            DataSchemaType.STRING -> {
-                // Check if it's an enum
-                if (isStringEnum(schema)) {
+            DataSchemaType.STRING -> when {
+                isStringEnum(schema) -> {
                     val enumName = asClassName(fieldName)
-                    val enumTypeName = ClassName("", enumName)
-                    val enumConstantValue = defaultValue.asString()
-                    val propSpec = createEnumDefault(asScreamingSnakeCase(fieldName), enumTypeName, enumConstantValue, enumName)
-                    propSpec
+                    createEnumDefault(constantName, ClassName("", enumName), defaultValue.asString(), enumName)
                 }
-                // Check if it's a date-time format
-                else if (isDateTimeFormat(schema)) {
-                    val value = defaultValue.asString()
-                    val propSpec = createInstantDefault(asScreamingSnakeCase(fieldName), value)
-                    propSpec
-                }
-                // Plain string
-                else {
-                    val value = defaultValue.asString()
-                    val propSpec = createStringDefault(asScreamingSnakeCase(fieldName), value)
-                    propSpec
-                }
+                isDateTimeFormat(schema) ->
+                    createInstantDefault(constantName, defaultValue.asString())
+                else ->
+                    createStringDefault(constantName, defaultValue.asString())
             }
 
             DataSchemaType.OBJECT -> {
-                // Check if it's an object enum (sealed class)
                 if (isObjectEnum(schema)) {
-                    // Default must be an object with a "name" field
                     if (!defaultValue.isObject) {
                         logger.warn("Object enum default for '$fieldName' is not an object, skipping")
                         return null
                     }
-                    val defaultObj = defaultValue.asObject()
-                    val nameField = defaultObj.getValue("name").orElse(null)
+                    val nameField = defaultValue.asObject().getValue("name").orElse(null)
                     if (nameField == null || !nameField.isString) {
                         logger.warn("Object enum default for '$fieldName' is missing 'name' field, skipping")
                         return null
                     }
-                    val nameValue = nameField.asString()
-                    val sealedTypeName = ClassName("", asClassName(fieldName))
-                    val objectInstanceName = asValidEnumConstant(nameValue)
-                    val propSpec = createObjectEnumDefault(asScreamingSnakeCase(fieldName), sealedTypeName, objectInstanceName)
-                    propSpec
+                    createObjectEnumDefault(constantName, ClassName("", asClassName(fieldName)), asValidEnumConstant(nameField.asString()))
                 } else {
-                    // EDGE-2: Nested object defaults - skip silently
                     null
                 }
             }
 
             DataSchemaType.ARRAY -> {
-                if (!defaultValue.isArray) {
-                    return null
-                }
+                if (!defaultValue.isArray) return null
                 val defaultArray = defaultValue.asArray()
                 val elementType = resolveArrayElementType(schema, packageName, fieldName)
                 if (defaultArray.isEmpty) {
-                    val propSpec = createEmptyListDefault(asScreamingSnakeCase(fieldName), elementType)
-                    propSpec
+                    createEmptyListDefault(constantName, elementType)
                 } else {
-                    val itemsEnum = resolveArrayItemsEnum(schema)
-                    val propSpec = createListDefault(asScreamingSnakeCase(fieldName), elementType, defaultArray, itemsEnum, fieldName)
-                    if (propSpec != null) {
-                        propSpec
-                    } else {
-                        logger.warn("Non-empty array default for '$fieldName' contains unsupported element type, skipping")
-                        null
-                    }
+                    createListDefault(constantName, elementType, defaultArray, resolveArrayItemsEnum(schema))
+                        ?: run {
+                            logger.warn("Non-empty array default for '$fieldName' contains unsupported element type, skipping")
+                            null
+                        }
                 }
             }
 
@@ -219,45 +116,32 @@ object DefaultValueExtractor {
         }
     }
 
-    /**
-     * Resolves the element type for an array schema.
-     */
     private fun resolveArrayElementType(schema: SingleDataSchema, packageName: String, fieldName: String): TypeName {
-        val schemaJson = schema.toJson()
-        val itemsValue = schemaJson.getValue("items").orElse(null)
-        if (itemsValue != null && itemsValue.isObject) {
-            val itemsJson = itemsValue.asObject()
-            val itemType = itemsJson.getValue("type").orElse(null)
-            if (itemType != null && itemType.isString) {
-                return when (itemType.asString()) {
-                    "boolean" -> BOOLEAN
-                    "integer" -> LONG
-                    "number" -> DOUBLE
-                    "string" -> {
-                        val hasEnum = itemsJson.getValue("enum").orElse(null)
-                        if (hasEnum != null && hasEnum.isArray && !hasEnum.asArray().isEmpty) {
-                            ClassName("", asClassName(fieldName) + "Item")
-                        } else {
-                            STRING
-                        }
-                    }
-                    "object" -> ClassName(packageName, asClassName(fieldName) + "Item")
-                    else -> STRING
-                }
+        val itemsJson = schema.toJson().getValue("items").orElse(null)?.asObject() ?: run {
+            logger.warn("Missing array items schema for '$fieldName', defaulting to String")
+            return STRING
+        }
+        val itemsSchema = SingleDataSchema.fromJson(itemsJson)
+        val itemType = itemsSchema.type.orElse(null) ?: run {
+            logger.warn("Missing type in array items schema for '$fieldName', defaulting to String")
+            return STRING
+        }
+        return when (itemType) {
+            DataSchemaType.BOOLEAN -> BOOLEAN
+            DataSchemaType.INTEGER -> LONG
+            DataSchemaType.NUMBER -> DOUBLE
+            DataSchemaType.STRING ->
+                if (isStringEnum(itemsSchema)) ClassName("", asClassName(fieldName) + "Item")
+                else STRING
+            DataSchemaType.OBJECT -> ClassName(packageName, asClassName(fieldName) + "Item")
+            DataSchemaType.ARRAY, DataSchemaType.NULL -> {
+                logger.warn("Unsupported array items type '$itemType' for '$fieldName', defaulting to String")
+                STRING
             }
         }
-        return STRING
     }
 
-    /**
-     * Creates a PropertySpec for a boolean default constant.
-     *
-     * Generates: `const val DEFAULT_<NAME>: Boolean = <value>`
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param value The boolean default value
-     * @return PropertySpec for the constant
-     */
+    /** Creates a PropertySpec for a boolean default constant. */
     internal fun createBooleanDefault(
         constantName: String,
         value: Boolean
@@ -268,15 +152,7 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Creates a PropertySpec for an integer (Long) default constant.
-     *
-     * Generates: `const val DEFAULT_<NAME>: Long = <value>`
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param value The Long default value
-     * @return PropertySpec for the constant
-     */
+    /** Creates a PropertySpec for an integer (Long) default constant. */
     internal fun createIntegerDefault(
         constantName: String,
         value: Long
@@ -287,15 +163,7 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Creates a PropertySpec for a number (Double) default constant.
-     *
-     * Generates: `const val DEFAULT_<NAME>: Double = <value>`
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param value The Double default value
-     * @return PropertySpec for the constant
-     */
+    /** Creates a PropertySpec for a number (Double) default constant. */
     internal fun createNumberDefault(
         constantName: String,
         value: Double
@@ -306,15 +174,7 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Creates a PropertySpec for a plain string default constant.
-     *
-     * Generates: `const val DEFAULT_<NAME>: String = "<value>"`
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param value The String default value
-     * @return PropertySpec for the constant
-     */
+    /** Creates a PropertySpec for a string default constant. */
     internal fun createStringDefault(
         constantName: String,
         value: String
@@ -325,15 +185,7 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Creates a PropertySpec for a date-time (Instant) default constant.
-     *
-     * Generates: `val DEFAULT_<NAME>: Instant = Instant.parse("<value>")`
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param value The ISO-8601 date-time string
-     * @return PropertySpec for the constant
-     */
+    /** Creates a PropertySpec for a date-time (Instant) default constant. */
     internal fun createInstantDefault(
         constantName: String,
         value: String
@@ -344,18 +196,7 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Creates a PropertySpec for a string enum default constant.
-     *
-     * Generates: `val DEFAULT_<NAME>: EnumType = EnumType.CONSTANT`
-     * Uses `asEnumConstantName()` to convert the default value to enum constant format.
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param enumTypeName The ClassName of the enum type (unqualified for inline enums)
-     * @param enumConstantValue The raw enum constant value from the schema default
-     * @param enumName The name of the enum class (for asEnumConstantName conversion)
-     * @return PropertySpec for the constant
-     */
+    /** Creates a PropertySpec for a string enum default constant. */
     internal fun createEnumDefault(
         constantName: String,
         enumTypeName: ClassName,
@@ -368,18 +209,7 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Creates a PropertySpec for an object enum (sealed class) default constant.
-     *
-     * Generates: `val DEFAULT_<NAME>: SealedType = SealedType.INSTANCE`
-     * Extracts the `"name"` field from the JSON object default and uses
-     * `asValidEnumConstant()` to convert to object name format.
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param sealedTypeName The ClassName of the sealed class type (unqualified for inline)
-     * @param objectInstanceName The name of the sealed class object instance
-     * @return PropertySpec for the constant
-     */
+    /** Creates a PropertySpec for an object enum (sealed class) default constant. */
     internal fun createObjectEnumDefault(
         constantName: String,
         sealedTypeName: ClassName,
@@ -390,15 +220,7 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Creates a PropertySpec for an empty list default constant.
-     *
-     * Generates: `val DEFAULT_<NAME>: List<T> = emptyList()`
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param elementType The type of elements in the list
-     * @return PropertySpec for the constant
-     */
+    /** Creates a PropertySpec for an empty list default constant. */
     internal fun createEmptyListDefault(
         constantName: String,
         elementType: TypeName
@@ -409,24 +231,12 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Creates a PropertySpec for a non-empty list default constant.
-     *
-     * Supports primitive element types (Boolean, Long, Double, String) and string enums.
-     *
-     * @param constantName The constant name in SCREAMING_SNAKE_CASE (without DEFAULT_ prefix)
-     * @param elementType The type of elements in the list
-     * @param defaultArray The JSON array containing the default values
-     * @param itemsEnum The enum values from the items schema, or null if not an enum array
-     * @param fieldName The original field name (for enum name resolution)
-     * @return PropertySpec for the constant, or null if the element type is unsupported
-     */
+    /** Creates a PropertySpec for a non-empty list default constant. Returns null if element type is unsupported. */
     internal fun createListDefault(
         constantName: String,
         elementType: TypeName,
         defaultArray: JsonArray,
-        itemsEnum: List<String>?,
-        fieldName: String
+        itemsEnum: List<String>?
     ): PropertySpec? {
         val elements = mutableListOf<CodeBlock>()
 
@@ -461,54 +271,28 @@ object DefaultValueExtractor {
             .build()
     }
 
-    /**
-     * Resolves enum values from the items schema of an array, if present.
-     *
-     * @param schema The array schema
-     * @return List of enum string values, or null if items is not a string enum
-     */
     private fun resolveArrayItemsEnum(schema: SingleDataSchema): List<String>? {
-        val schemaJson = schema.toJson()
-        val itemsValue = schemaJson.getValue("items").orElse(null) ?: return null
-        if (!itemsValue.isObject) return null
-        val itemsJson = itemsValue.asObject()
-        val itemType = itemsJson.getValue("type").orElse(null)
-        if (itemType == null || !itemType.isString || itemType.asString() != "string") return null
-        val enumArray = itemsJson.getValue("enum").orElse(null) ?: return null
-        if (!enumArray.isArray) return null
-        return enumArray.asArray().map { it.asString() }
+        val itemsJson = schema.toJson().getValue("items").orElse(null)?.asObject() ?: return null
+        val itemsSchema = SingleDataSchema.fromJson(itemsJson)
+        if (!isStringEnum(itemsSchema)) return null
+        return itemsSchema.enum.map { it.asString() }
     }
 
-    /**
-     * Determines if a schema represents a string enum.
-     *
-     * @param schema The SingleDataSchema to check
-     * @return true if this is a string type with enum values
-     */
+    /** Checks if a schema represents a string enum. */
     internal fun isStringEnum(schema: SingleDataSchema): Boolean {
         val schemaType = schema.type.orElse(null) ?: return false
         if (schemaType != DataSchemaType.STRING) return false
         return schema.enum.isNotEmpty()
     }
 
-    /**
-     * Determines if a schema represents an object enum (sealed class).
-     *
-     * @param schema The SingleDataSchema to check
-     * @return true if this is an object type with enum values
-     */
+    /** Checks if a schema represents an object enum (sealed class). */
     internal fun isObjectEnum(schema: SingleDataSchema): Boolean {
         val schemaType = schema.type.orElse(null) ?: return false
         if (schemaType != DataSchemaType.OBJECT) return false
         return schema.enum.isNotEmpty()
     }
 
-    /**
-     * Determines if a schema has a date-time format.
-     *
-     * @param schema The SingleDataSchema to check
-     * @return true if this is a string type with format "date-time"
-     */
+    /** Checks if a schema has a date-time format. */
     internal fun isDateTimeFormat(schema: SingleDataSchema): Boolean {
         val schemaType = schema.type.orElse(null) ?: return false
         if (schemaType != DataSchemaType.STRING) return false

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractor.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractor.kt
@@ -51,15 +51,6 @@ object DefaultValueExtractor {
     private val logger = LoggerFactory.getLogger(DefaultValueExtractor::class.java)
 
     /**
-     * Represents an extracted default value with its corresponding property specification.
-     *
-     * @property propertySpec The KotlinPoet PropertySpec for the default constant
-     */
-    data class ExtractedDefault(
-        val propertySpec: PropertySpec
-    )
-
-    /**
      * Extracts default value constants from a collection of properties.
      *
      * Processes each property in the map and extracts any defined default values,
@@ -67,12 +58,12 @@ object DefaultValueExtractor {
      *
      * @param properties Map of property names to their Property definitions
      * @param packageName The package name for type resolution
-     * @return List of extracted default constants, empty if no defaults found
+     * @return List of PropertySpec for DEFAULT_* constants, empty if no defaults found
      */
     fun extractDefaultConstants(
         properties: Map<String, Property>,
         packageName: String
-    ): List<ExtractedDefault> {
+    ): List<PropertySpec> {
         return properties.mapNotNull { (name, property) ->
             extractDefaultFromProperty(name, property, packageName)
         }
@@ -86,12 +77,12 @@ object DefaultValueExtractor {
      *
      * @param fields Map of field names to their SingleDataSchema definitions
      * @param packageName The package name for type resolution
-     * @return List of extracted default constants, empty if no defaults found
+     * @return List of PropertySpec for DEFAULT_* constants, empty if no defaults found
      */
     fun extractDefaultConstantsFromFields(
         fields: Map<String, SingleDataSchema>,
         packageName: String
-    ): List<ExtractedDefault> {
+    ): List<PropertySpec> {
         return fields.mapNotNull { (name, schema) ->
             extractDefaultFromSchema(name, schema, packageName)
         }
@@ -112,7 +103,7 @@ object DefaultValueExtractor {
         propertyName: String,
         property: Property,
         packageName: String
-    ): ExtractedDefault? {
+    ): PropertySpec? {
         // Property extends SingleDataSchema, so we can treat it as a schema
         return extractDefaultFromSchema(propertyName, property, packageName)
     }
@@ -128,11 +119,11 @@ object DefaultValueExtractor {
      * @param packageName The package name for type resolution
      * @return The extracted default, or null if no default is defined or type is unsupported
      */
-    fun extractDefaultFromSchema(
+    internal fun extractDefaultFromSchema(
         fieldName: String,
         schema: SingleDataSchema,
         packageName: String
-    ): ExtractedDefault? {
+    ): PropertySpec? {
         val defaultValue = schema.default.orElse(null) ?: return null
         val schemaType = schema.type.orElse(null) ?: return null
 
@@ -140,19 +131,19 @@ object DefaultValueExtractor {
             DataSchemaType.BOOLEAN -> {
                 val value = defaultValue.asBoolean()
                 val propSpec = createBooleanDefault(asScreamingSnakeCase(fieldName), value)
-                ExtractedDefault(propSpec)
+                propSpec
             }
 
             DataSchemaType.INTEGER -> {
                 val value = defaultValue.asLong()
                 val propSpec = createIntegerDefault(asScreamingSnakeCase(fieldName), value)
-                ExtractedDefault(propSpec)
+                propSpec
             }
 
             DataSchemaType.NUMBER -> {
                 val value = defaultValue.asDouble()
                 val propSpec = createNumberDefault(asScreamingSnakeCase(fieldName), value)
-                ExtractedDefault(propSpec)
+                propSpec
             }
 
             DataSchemaType.STRING -> {
@@ -162,19 +153,19 @@ object DefaultValueExtractor {
                     val enumTypeName = ClassName("", enumName)
                     val enumConstantValue = defaultValue.asString()
                     val propSpec = createEnumDefault(asScreamingSnakeCase(fieldName), enumTypeName, enumConstantValue, enumName)
-                    ExtractedDefault(propSpec)
+                    propSpec
                 }
                 // Check if it's a date-time format
                 else if (isDateTimeFormat(schema)) {
                     val value = defaultValue.asString()
                     val propSpec = createInstantDefault(asScreamingSnakeCase(fieldName), value)
-                    ExtractedDefault(propSpec)
+                    propSpec
                 }
                 // Plain string
                 else {
                     val value = defaultValue.asString()
                     val propSpec = createStringDefault(asScreamingSnakeCase(fieldName), value)
-                    ExtractedDefault(propSpec)
+                    propSpec
                 }
             }
 
@@ -196,7 +187,7 @@ object DefaultValueExtractor {
                     val sealedTypeName = ClassName("", asClassName(fieldName))
                     val objectInstanceName = asValidEnumConstant(nameValue)
                     val propSpec = createObjectEnumDefault(asScreamingSnakeCase(fieldName), sealedTypeName, objectInstanceName)
-                    ExtractedDefault(propSpec)
+                    propSpec
                 } else {
                     // EDGE-2: Nested object defaults - skip silently
                     null
@@ -211,12 +202,12 @@ object DefaultValueExtractor {
                 val elementType = resolveArrayElementType(schema, packageName, fieldName)
                 if (defaultArray.isEmpty) {
                     val propSpec = createEmptyListDefault(asScreamingSnakeCase(fieldName), elementType)
-                    ExtractedDefault(propSpec)
+                    propSpec
                 } else {
                     val itemsEnum = resolveArrayItemsEnum(schema)
                     val propSpec = createListDefault(asScreamingSnakeCase(fieldName), elementType, defaultArray, itemsEnum, fieldName)
                     if (propSpec != null) {
-                        ExtractedDefault(propSpec)
+                        propSpec
                     } else {
                         logger.warn("Non-empty array default for '$fieldName' contains unsupported element type, skipping")
                         null

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGeneratorDefaultConstantsTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGeneratorDefaultConstantsTest.kt
@@ -160,7 +160,7 @@ class ClassGeneratorDefaultConstantsTest {
                 .build()
         )
 
-        ClassGenerator.addDefaultConstantsToCompanion(companionBuilder, defaultConstants)
+        ClassGenerator.addDefaultsToCompanion(companionBuilder, defaultConstants)
 
         val companion = companionBuilder.build()
         assertEquals(1, companion.propertySpecs.size)

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGeneratorDefaultConstantsTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGeneratorDefaultConstantsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test
  * These tests verify that ClassGenerator properly integrates with DefaultValueExtractor
  * for extracting and placing DEFAULT_* constants on companion objects.
  *
- * @since 1.0.0
+ * @since 1.1.0
  */
 class ClassGeneratorDefaultConstantsTest {
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGeneratorDefaultConstantsTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGeneratorDefaultConstantsTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.clazz
+
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Integration tests for ClassGenerator's default constant extraction functionality.
+ *
+ * These tests verify that ClassGenerator properly integrates with DefaultValueExtractor
+ * for extracting and placing DEFAULT_* constants on companion objects.
+ *
+ * @since 1.0.0
+ */
+class ClassGeneratorDefaultConstantsTest {
+
+    private lateinit var pathFunSpec: FunSpec
+
+    @BeforeEach
+    fun setUp() {
+        pathFunSpec = FunSpec.builder("startPath")
+            .addModifiers(KModifier.OVERRIDE)
+            .returns(String::class)
+            .addStatement("return %S", "test")
+            .build()
+    }
+
+    @Test
+    fun `should add default constants to new companion object`() {
+        val typeSpecBuilder = TypeSpec.classBuilder("TestClass")
+        val defaultConstants = listOf(
+            PropertySpec.builder("DEFAULT_IS_ENABLED", BOOLEAN)
+                .addModifiers(KModifier.CONST)
+                .initializer("true")
+                .build(),
+            PropertySpec.builder("DEFAULT_MAX_RETRIES", LONG)
+                .addModifiers(KModifier.CONST)
+                .initializer("3L")
+                .build()
+        )
+
+        ClassGenerator.mergeOrAddCompanionObject(typeSpecBuilder, pathFunSpec, defaultConstants)
+
+        val typeSpec = typeSpecBuilder.build()
+        val companion = typeSpec.typeSpecs.find { it.isCompanion }
+        assertNotNull(companion)
+        assertEquals(2, companion!!.propertySpecs.size)
+        assertTrue(companion.propertySpecs.any { it.name == "DEFAULT_IS_ENABLED" })
+        assertTrue(companion.propertySpecs.any { it.name == "DEFAULT_MAX_RETRIES" })
+    }
+
+    @Test
+    fun `should merge default constants into existing companion object`() {
+        val existingCompanion = TypeSpec.companionObjectBuilder()
+            .addSuperinterface(ClassName("org.eclipse.ditto.wot.kotlin.generator.common.path", "HasPath"))
+            .addFunction(pathFunSpec)
+            .addProperty(
+                PropertySpec.builder("EXISTING_CONSTANT", String::class)
+                    .addModifiers(KModifier.CONST)
+                    .initializer("%S", "existing")
+                    .build()
+            )
+            .build()
+
+        val typeSpecBuilder = TypeSpec.classBuilder("TestClass")
+            .addType(existingCompanion)
+
+        val defaultConstants = listOf(
+            PropertySpec.builder("DEFAULT_IS_ENABLED", BOOLEAN)
+                .addModifiers(KModifier.CONST)
+                .initializer("true")
+                .build()
+        )
+
+        ClassGenerator.mergeOrAddCompanionObject(typeSpecBuilder, pathFunSpec, defaultConstants)
+
+        val typeSpec = typeSpecBuilder.build()
+        val companion = typeSpec.typeSpecs.find { it.isCompanion }
+        assertNotNull(companion)
+        // Should have both existing and new constants
+        assertEquals(2, companion!!.propertySpecs.size)
+        assertTrue(companion.propertySpecs.any { it.name == "EXISTING_CONSTANT" })
+        assertTrue(companion.propertySpecs.any { it.name == "DEFAULT_IS_ENABLED" })
+    }
+
+    @Test
+    fun `should not duplicate existing constants when merging`() {
+        val existingCompanion = TypeSpec.companionObjectBuilder()
+            .addSuperinterface(ClassName("org.eclipse.ditto.wot.kotlin.generator.common.path", "HasPath"))
+            .addFunction(pathFunSpec)
+            .addProperty(
+                PropertySpec.builder("DEFAULT_IS_ENABLED", BOOLEAN)
+                    .addModifiers(KModifier.CONST)
+                    .initializer("true")
+                    .build()
+            )
+            .build()
+
+        val typeSpecBuilder = TypeSpec.classBuilder("TestClass")
+            .addType(existingCompanion)
+
+        val defaultConstants = listOf(
+            PropertySpec.builder("DEFAULT_IS_ENABLED", BOOLEAN)
+                .addModifiers(KModifier.CONST)
+                .initializer("true")
+                .build()
+        )
+
+        ClassGenerator.mergeOrAddCompanionObject(typeSpecBuilder, pathFunSpec, defaultConstants)
+
+        val typeSpec = typeSpecBuilder.build()
+        val companion = typeSpec.typeSpecs.find { it.isCompanion }
+        assertNotNull(companion)
+        // Should NOT duplicate the constant
+        assertEquals(1, companion!!.propertySpecs.size)
+    }
+
+    @Test
+    fun `should handle empty default constants list`() {
+        val typeSpecBuilder = TypeSpec.classBuilder("TestClass")
+        val defaultConstants = emptyList<PropertySpec>()
+
+        ClassGenerator.mergeOrAddCompanionObject(typeSpecBuilder, pathFunSpec, defaultConstants)
+
+        val typeSpec = typeSpecBuilder.build()
+        val companion = typeSpec.typeSpecs.find { it.isCompanion }
+        assertNotNull(companion)
+        // Should still have companion with HasPath but no extra constants
+        assertTrue(companion!!.propertySpecs.isEmpty())
+    }
+
+    @Test
+    fun `should add default constants to companion builder`() {
+        val companionBuilder = TypeSpec.companionObjectBuilder()
+            .addSuperinterface(ClassName("org.eclipse.ditto.wot.kotlin.generator.common.path", "HasPath"))
+
+        val defaultConstants = listOf(
+            PropertySpec.builder("DEFAULT_TEMPERATURE", com.squareup.kotlinpoet.DOUBLE)
+                .addModifiers(KModifier.CONST)
+                .initializer("22.5")
+                .build()
+        )
+
+        ClassGenerator.addDefaultConstantsToCompanion(companionBuilder, defaultConstants)
+
+        val companion = companionBuilder.build()
+        assertEquals(1, companion.propertySpecs.size)
+        assertTrue(companion.propertySpecs.any { it.name == "DEFAULT_TEMPERATURE" })
+    }
+
+    @Test
+    fun `should support single-argument version for backward compatibility`() {
+        val typeSpecBuilder = TypeSpec.classBuilder("TestClass")
+
+        ClassGenerator.mergeOrAddCompanionObject(typeSpecBuilder, pathFunSpec)
+
+        val typeSpec = typeSpecBuilder.build()
+        val companion = typeSpec.typeSpecs.find { it.isCompanion }
+        assertNotNull(companion)
+        assertTrue(companion!!.funSpecs.any { it.name == "startPath" })
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DefaultValueGenerationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DefaultValueGenerationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,9 +17,9 @@ import org.eclipse.ditto.json.JsonObject
 import org.eclipse.ditto.wot.kotlin.generator.plugin.ThingModelGenerator
 import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
 import org.eclipse.ditto.wot.model.ThingModel
+import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.Comparator
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.test.assertFalse
@@ -31,725 +31,310 @@ import kotlin.test.assertFalse
  * are properly generated from WoT Thing Model schema default values and placed
  * on the correct companion objects.
  *
- * @since 1.0.0
+ * @since 1.1.0
  */
 class DefaultValueGenerationTest {
 
-    @Test
-    fun `should generate const val for boolean default in companion object`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Boolean Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "isEnabled": {
-                          "title": "Is Enabled",
-                          "type": "boolean",
-                          "default": true
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.boolean"
+    @TempDir
+    lateinit var outputDir: Path
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
+    private fun generateAndReadAttributes(propertiesJson: String, pkg: String): String = runBlocking {
+        val thingModel = ThingModel.fromJson(
+            JsonObject.of("""
+                {
+                  "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                  "@type": "tm:ThingModel",
+                  "title": "Test",
+                  "version": { "model": "1.0.0" },
+                  "properties": { $propertiesJson }
+                }
+            """.trimIndent())
+        )
 
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            assertTrue(Files.exists(attributesFile), "Expected generated attributes file at: $attributesFile")
-
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                attributesContent.contains("const val DEFAULT_IS_ENABLED: Boolean = true"),
-                "Expected DEFAULT_IS_ENABLED constant in companion object"
+        ThingModelGenerator.generate(
+            thingModel,
+            GeneratorConfiguration(
+                thingModelUrl = "in-memory",
+                outputPackage = pkg,
+                outputDirectory = outputDir.toFile()
             )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        )
+
+        val attributesFile = outputDir.resolve("${pkg.replace('.', '/')}/attributes/Attributes.kt")
+        assertTrue(Files.exists(attributesFile), "Expected generated attributes file at: $attributesFile")
+        Files.readString(attributesFile)
     }
 
     @Test
-    fun `should generate const val for boolean false default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Boolean False Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "isDisabled": {
-                          "title": "Is Disabled",
-                          "type": "boolean",
-                          "default": false
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.booleanfalse"
+    fun `should generate const val for boolean default in companion object`() {
+        val content = generateAndReadAttributes("""
+            "isEnabled": {
+              "title": "Is Enabled",
+              "type": "boolean",
+              "default": true
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.boolean")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                attributesContent.contains("const val DEFAULT_IS_DISABLED: Boolean = false"),
-                "Expected DEFAULT_IS_DISABLED constant for false value"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            content.contains("const val DEFAULT_IS_ENABLED: Boolean = true"),
+            "Expected DEFAULT_IS_ENABLED constant in companion object"
+        )
     }
 
     @Test
-    fun `should generate const val for integer default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Integer Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "maxRetries": {
-                          "title": "Max Retries",
-                          "type": "integer",
-                          "default": 5
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.integer"
+    fun `should generate const val for boolean false default`() {
+        val content = generateAndReadAttributes("""
+            "isDisabled": {
+              "title": "Is Disabled",
+              "type": "boolean",
+              "default": false
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.booleanfalse")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                attributesContent.contains("const val DEFAULT_MAX_RETRIES: Long = 5"),
-                "Expected DEFAULT_MAX_RETRIES constant"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            content.contains("const val DEFAULT_IS_DISABLED: Boolean = false"),
+            "Expected DEFAULT_IS_DISABLED constant for false value"
+        )
     }
 
     @Test
-    fun `should generate const val for zero integer default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Zero Integer Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "retryCount": {
-                          "title": "Retry Count",
-                          "type": "integer",
-                          "default": 0
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.zeroint"
+    fun `should generate const val for integer default`() {
+        val content = generateAndReadAttributes("""
+            "maxRetries": {
+              "title": "Max Retries",
+              "type": "integer",
+              "default": 5
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.integer")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                attributesContent.contains("const val DEFAULT_RETRY_COUNT: Long = 0"),
-                "Expected DEFAULT_RETRY_COUNT constant for zero value"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            content.contains("const val DEFAULT_MAX_RETRIES: Long = 5"),
+            "Expected DEFAULT_MAX_RETRIES constant"
+        )
     }
 
     @Test
-    fun `should generate const val for number default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Number Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "temperature": {
-                          "title": "Temperature",
-                          "type": "number",
-                          "default": 22.5
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.number"
+    fun `should generate const val for zero integer default`() {
+        val content = generateAndReadAttributes("""
+            "retryCount": {
+              "title": "Retry Count",
+              "type": "integer",
+              "default": 0
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.zeroint")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                attributesContent.contains("const val DEFAULT_TEMPERATURE: Double = 22.5"),
-                "Expected DEFAULT_TEMPERATURE constant"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            content.contains("const val DEFAULT_RETRY_COUNT: Long = 0"),
+            "Expected DEFAULT_RETRY_COUNT constant for zero value"
+        )
     }
 
     @Test
-    fun `should generate const val for string default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "String Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "name": {
-                          "title": "Name",
-                          "type": "string",
-                          "default": "unknown"
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.string"
+    fun `should generate const val for number default`() {
+        val content = generateAndReadAttributes("""
+            "temperature": {
+              "title": "Temperature",
+              "type": "number",
+              "default": 22.5
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.number")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                Regex("""const val DEFAULT_NAME: String = "unknown"""").containsMatchIn(attributesContent),
-                "Expected DEFAULT_NAME constant with string value"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            content.contains("const val DEFAULT_TEMPERATURE: Double = 22.5"),
+            "Expected DEFAULT_TEMPERATURE constant"
+        )
     }
 
     @Test
-    fun `should generate val for datetime default with Instant parse`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "DateTime Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "createdAt": {
-                          "title": "Created At",
-                          "type": "string",
-                          "format": "date-time",
-                          "default": "2024-01-01T00:00:00Z"
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.datetime"
+    fun `should generate const val for string default`() {
+        val content = generateAndReadAttributes("""
+            "name": {
+              "title": "Name",
+              "type": "string",
+              "default": "unknown"
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.string")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                Regex("""val DEFAULT_CREATED_AT: Instant = Instant\.parse\("2024-01-01T00:00:00Z"\)""")
-                    .containsMatchIn(attributesContent),
-                "Expected DEFAULT_CREATED_AT with Instant.parse initializer"
-            )
-            assertFalse(
-                attributesContent.contains("const val DEFAULT_CREATED_AT"),
-                "Instant default should not use const val"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            Regex("""const val DEFAULT_NAME: String = "unknown"""").containsMatchIn(content),
+            "Expected DEFAULT_NAME constant with string value"
+        )
     }
 
     @Test
-    fun `should generate val for string enum default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Enum Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "status": {
-                          "title": "Status",
-                          "type": "string",
-                          "enum": ["active", "inactive", "pending"],
-                          "default": "active"
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.stringenum"
+    fun `should generate val for datetime default with Instant parse`() {
+        val content = generateAndReadAttributes("""
+            "createdAt": {
+              "title": "Created At",
+              "type": "string",
+              "format": "date-time",
+              "default": "2024-01-01T00:00:00Z"
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.datetime")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                Regex("""val DEFAULT_STATUS: Status = Status\.ACTIVE""").containsMatchIn(attributesContent),
-                "Expected DEFAULT_STATUS with enum constant reference"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            Regex("""val DEFAULT_CREATED_AT: Instant = Instant\.parse\("2024-01-01T00:00:00Z"\)""")
+                .containsMatchIn(content),
+            "Expected DEFAULT_CREATED_AT with Instant.parse initializer"
+        )
+        assertFalse(
+            content.contains("const val DEFAULT_CREATED_AT"),
+            "Instant default should not use const val"
+        )
     }
 
     @Test
-    fun `should generate val for object enum default with name field`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Object Enum Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "lowBatteryBehavior": {
-                          "title": "Low Battery Behavior",
-                          "type": "object",
-                          "enum": [
-                            { "name": "shutdown", "description": "Shut down the device" },
-                            { "name": "lowPower", "description": "Enter low power mode" }
-                          ],
-                          "default": { "name": "shutdown" }
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.objectenum"
+    fun `should generate val for string enum default`() {
+        val content = generateAndReadAttributes("""
+            "status": {
+              "title": "Status",
+              "type": "string",
+              "enum": ["active", "inactive", "pending"],
+              "default": "active"
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.stringenum")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                Regex("""val DEFAULT_LOW_BATTERY_BEHAVIOR: LowBatteryBehavior = LowBatteryBehavior\.\w+""")
-                    .containsMatchIn(attributesContent),
-                "Expected DEFAULT_LOW_BATTERY_BEHAVIOR with sealed class instance"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            Regex("""val DEFAULT_STATUS: Status = Status\.ACTIVE""").containsMatchIn(content),
+            "Expected DEFAULT_STATUS with enum constant reference"
+        )
     }
 
     @Test
-    fun `should generate val for empty array default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Empty Array Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "tags": {
-                          "title": "Tags",
-                          "type": "array",
-                          "items": { "type": "string" },
-                          "default": []
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.emptyarray"
+    fun `should generate val for object enum default with name field`() {
+        val content = generateAndReadAttributes("""
+            "lowBatteryBehavior": {
+              "title": "Low Battery Behavior",
+              "type": "object",
+              "enum": [
+                { "name": "shutdown", "description": "Shut down the device" },
+                { "name": "lowPower", "description": "Enter low power mode" }
+              ],
+              "default": { "name": "shutdown" }
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.objectenum")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                Regex("""val DEFAULT_TAGS: List<\w+> = emptyList\(\)""").containsMatchIn(attributesContent),
-                "Expected DEFAULT_TAGS with emptyList() initializer"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            Regex("""val DEFAULT_LOW_BATTERY_BEHAVIOR: LowBatteryBehavior = LowBatteryBehavior\.\w+""")
+                .containsMatchIn(content),
+            "Expected DEFAULT_LOW_BATTERY_BEHAVIOR with sealed class instance"
+        )
     }
 
     @Test
-    fun `should generate listOf for non-empty string array default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Non-Empty Array Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "defaultTags": {
-                          "title": "Default Tags",
-                          "type": "array",
-                          "items": { "type": "string" },
-                          "default": ["tag1", "tag2"]
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.nonemptyarray"
+    fun `should generate val for empty array default`() {
+        val content = generateAndReadAttributes("""
+            "tags": {
+              "title": "Tags",
+              "type": "array",
+              "items": { "type": "string" },
+              "default": []
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.emptyarray")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                attributesContent.contains("DEFAULT_DEFAULT_TAGS"),
-                "Non-empty string array default should generate DEFAULT_ constant"
-            )
-            assertTrue(
-                attributesContent.contains("listOf("),
-                "Non-empty string array default should use listOf()"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            Regex("""val DEFAULT_TAGS: List<\w+> = emptyList\(\)""").containsMatchIn(content),
+            "Expected DEFAULT_TAGS with emptyList() initializer"
+        )
     }
 
     @Test
-    fun `should generate listOf with enum values for non-empty enum array default`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Enum Array Default Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "enabledSeverities": {
-                          "title": "Enabled Severities",
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": ["OK", "WARNING", "CRITICAL"]
-                          },
-                          "default": ["OK", "WARNING"]
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.enumarray"
+    fun `should generate listOf for non-empty string array default`() {
+        val content = generateAndReadAttributes("""
+            "defaultTags": {
+              "title": "Default Tags",
+              "type": "array",
+              "items": { "type": "string" },
+              "default": ["tag1", "tag2"]
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.nonemptyarray")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                attributesContent.contains("DEFAULT_ENABLED_SEVERITIES"),
-                "Enum array default should generate DEFAULT_ constant"
-            )
-            assertTrue(
-                attributesContent.contains("EnabledSeveritiesItem"),
-                "Enum array default should reference the enum type"
-            )
-            assertTrue(
-                attributesContent.contains("listOf("),
-                "Enum array default should use listOf()"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(content.contains("DEFAULT_DEFAULT_TAGS"), "Non-empty string array default should generate DEFAULT_ constant")
+        assertTrue(content.contains("listOf("), "Non-empty string array default should use listOf()")
     }
 
     @Test
-    fun `should skip object enum default without name field`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Object Enum Missing Name Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "behavior": {
-                          "title": "Behavior",
-                          "type": "object",
-                          "enum": [
-                            { "name": "option1" },
-                            { "name": "option2" }
-                          ],
-                          "default": { "value": "something" }
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.missingname"
+    fun `should generate listOf with enum values for non-empty enum array default`() {
+        val content = generateAndReadAttributes("""
+            "enabledSeverities": {
+              "title": "Enabled Severities",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["OK", "WARNING", "CRITICAL"]
+              },
+              "default": ["OK", "WARNING"]
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.enumarray")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertFalse(
-                attributesContent.contains("DEFAULT_BEHAVIOR"),
-                "Object enum default without 'name' field should be skipped"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(content.contains("DEFAULT_ENABLED_SEVERITIES"), "Enum array default should generate DEFAULT_ constant")
+        assertTrue(content.contains("EnabledSeveritiesItem"), "Enum array default should reference the enum type")
+        assertTrue(content.contains("listOf("), "Enum array default should use listOf()")
     }
 
     @Test
-    fun `should convert camelCase property name to SCREAMING_SNAKE_CASE constant`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "CamelCase Property Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "maxRetryCount": {
-                          "title": "Max Retry Count",
-                          "type": "integer",
-                          "default": 3
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.camelcase"
+    fun `should skip object enum default without name field`() {
+        val content = generateAndReadAttributes("""
+            "behavior": {
+              "title": "Behavior",
+              "type": "object",
+              "enum": [
+                { "name": "option1" },
+                { "name": "option2" }
+              ],
+              "default": { "value": "something" }
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.missingname")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-            assertTrue(
-                attributesContent.contains("DEFAULT_MAX_RETRY_COUNT"),
-                "Expected property name converted to SCREAMING_SNAKE_CASE"
-            )
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertFalse(
+            content.contains("DEFAULT_BEHAVIOR"),
+            "Object enum default without 'name' field should be skipped"
+        )
     }
 
     @Test
-    fun `should generate multiple default constants in same companion object`() = runBlocking {
-        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
-        try {
-            val thingModel = ThingModel.fromJson(
-                JsonObject.of("""
-                    {
-                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
-                      "@type": "tm:ThingModel",
-                      "title": "Multiple Defaults Test",
-                      "version": { "model": "1.0.0" },
-                      "properties": {
-                        "isEnabled": {
-                          "title": "Is Enabled",
-                          "type": "boolean",
-                          "default": true
-                        },
-                        "maxRetries": {
-                          "title": "Max Retries",
-                          "type": "integer",
-                          "default": 3
-                        },
-                        "temperature": {
-                          "title": "Temperature",
-                          "type": "number",
-                          "default": 22.5
-                        },
-                        "noDefault": {
-                          "title": "No Default",
-                          "type": "string"
-                        }
-                      }
-                    }
-                """.trimIndent())
-            )
-            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.multiple"
+    fun `should convert camelCase property name to SCREAMING_SNAKE_CASE constant`() {
+        val content = generateAndReadAttributes("""
+            "maxRetryCount": {
+              "title": "Max Retry Count",
+              "type": "integer",
+              "default": 3
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.camelcase")
 
-            ThingModelGenerator.generate(
-                thingModel,
-                GeneratorConfiguration(
-                    thingModelUrl = "in-memory",
-                    outputPackage = outputPackage,
-                    outputDirectory = outputDir.toFile()
-                )
-            )
-
-            val packagePath = outputPackage.replace('.', '/')
-            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
-            val attributesContent = Files.readString(attributesFile)
-
-            assertTrue(attributesContent.contains("DEFAULT_IS_ENABLED"), "Expected DEFAULT_IS_ENABLED")
-            assertTrue(attributesContent.contains("DEFAULT_MAX_RETRIES"), "Expected DEFAULT_MAX_RETRIES")
-            assertTrue(attributesContent.contains("DEFAULT_TEMPERATURE"), "Expected DEFAULT_TEMPERATURE")
-            assertFalse(attributesContent.contains("DEFAULT_NO_DEFAULT"), "Should not have constant for property without default")
-        } finally {
-            deleteRecursively(outputDir)
-        }
+        assertTrue(
+            content.contains("DEFAULT_MAX_RETRY_COUNT"),
+            "Expected property name converted to SCREAMING_SNAKE_CASE"
+        )
     }
 
-    private fun deleteRecursively(path: Path) {
-        if (!Files.exists(path)) return
-        Files.walk(path)
-            .sorted(Comparator.reverseOrder())
-            .forEach { Files.deleteIfExists(it) }
+    @Test
+    fun `should generate multiple default constants in same companion object`() {
+        val content = generateAndReadAttributes("""
+            "isEnabled": {
+              "title": "Is Enabled",
+              "type": "boolean",
+              "default": true
+            },
+            "maxRetries": {
+              "title": "Max Retries",
+              "type": "integer",
+              "default": 3
+            },
+            "temperature": {
+              "title": "Temperature",
+              "type": "number",
+              "default": 22.5
+            },
+            "noDefault": {
+              "title": "No Default",
+              "type": "string"
+            }
+        """.trimIndent(), "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.multiple")
+
+        assertTrue(content.contains("DEFAULT_IS_ENABLED"), "Expected DEFAULT_IS_ENABLED")
+        assertTrue(content.contains("DEFAULT_MAX_RETRIES"), "Expected DEFAULT_MAX_RETRIES")
+        assertTrue(content.contains("DEFAULT_TEMPERATURE"), "Expected DEFAULT_TEMPERATURE")
+        assertFalse(content.contains("DEFAULT_NO_DEFAULT"), "Should not have constant for property without default")
     }
 }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DefaultValueGenerationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DefaultValueGenerationTest.kt
@@ -1,0 +1,755 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.common
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.kotlin.generator.plugin.ThingModelGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
+import org.eclipse.ditto.wot.model.ThingModel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+/**
+ * Integration tests for default value constant generation in generated Kotlin code.
+ *
+ * Tests the full code generation pipeline to verify that DEFAULT_* constants
+ * are properly generated from WoT Thing Model schema default values and placed
+ * on the correct companion objects.
+ *
+ * @since 1.0.0
+ */
+class DefaultValueGenerationTest {
+
+    @Test
+    fun `should generate const val for boolean default in companion object`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Boolean Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "isEnabled": {
+                          "title": "Is Enabled",
+                          "type": "boolean",
+                          "default": true
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.boolean"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            assertTrue(Files.exists(attributesFile), "Expected generated attributes file at: $attributesFile")
+
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                attributesContent.contains("const val DEFAULT_IS_ENABLED: Boolean = true"),
+                "Expected DEFAULT_IS_ENABLED constant in companion object"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate const val for boolean false default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Boolean False Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "isDisabled": {
+                          "title": "Is Disabled",
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.booleanfalse"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                attributesContent.contains("const val DEFAULT_IS_DISABLED: Boolean = false"),
+                "Expected DEFAULT_IS_DISABLED constant for false value"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate const val for integer default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Integer Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "maxRetries": {
+                          "title": "Max Retries",
+                          "type": "integer",
+                          "default": 5
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.integer"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                attributesContent.contains("const val DEFAULT_MAX_RETRIES: Long = 5"),
+                "Expected DEFAULT_MAX_RETRIES constant"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate const val for zero integer default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Zero Integer Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "retryCount": {
+                          "title": "Retry Count",
+                          "type": "integer",
+                          "default": 0
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.zeroint"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                attributesContent.contains("const val DEFAULT_RETRY_COUNT: Long = 0"),
+                "Expected DEFAULT_RETRY_COUNT constant for zero value"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate const val for number default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Number Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "temperature": {
+                          "title": "Temperature",
+                          "type": "number",
+                          "default": 22.5
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.number"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                attributesContent.contains("const val DEFAULT_TEMPERATURE: Double = 22.5"),
+                "Expected DEFAULT_TEMPERATURE constant"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate const val for string default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "String Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "name": {
+                          "title": "Name",
+                          "type": "string",
+                          "default": "unknown"
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.string"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                Regex("""const val DEFAULT_NAME: String = "unknown"""").containsMatchIn(attributesContent),
+                "Expected DEFAULT_NAME constant with string value"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate val for datetime default with Instant parse`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "DateTime Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "createdAt": {
+                          "title": "Created At",
+                          "type": "string",
+                          "format": "date-time",
+                          "default": "2024-01-01T00:00:00Z"
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.datetime"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                Regex("""val DEFAULT_CREATED_AT: Instant = Instant\.parse\("2024-01-01T00:00:00Z"\)""")
+                    .containsMatchIn(attributesContent),
+                "Expected DEFAULT_CREATED_AT with Instant.parse initializer"
+            )
+            assertFalse(
+                attributesContent.contains("const val DEFAULT_CREATED_AT"),
+                "Instant default should not use const val"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate val for string enum default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Enum Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "status": {
+                          "title": "Status",
+                          "type": "string",
+                          "enum": ["active", "inactive", "pending"],
+                          "default": "active"
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.stringenum"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                Regex("""val DEFAULT_STATUS: Status = Status\.ACTIVE""").containsMatchIn(attributesContent),
+                "Expected DEFAULT_STATUS with enum constant reference"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate val for object enum default with name field`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Object Enum Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "lowBatteryBehavior": {
+                          "title": "Low Battery Behavior",
+                          "type": "object",
+                          "enum": [
+                            { "name": "shutdown", "description": "Shut down the device" },
+                            { "name": "lowPower", "description": "Enter low power mode" }
+                          ],
+                          "default": { "name": "shutdown" }
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.objectenum"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                Regex("""val DEFAULT_LOW_BATTERY_BEHAVIOR: LowBatteryBehavior = LowBatteryBehavior\.\w+""")
+                    .containsMatchIn(attributesContent),
+                "Expected DEFAULT_LOW_BATTERY_BEHAVIOR with sealed class instance"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate val for empty array default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Empty Array Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "tags": {
+                          "title": "Tags",
+                          "type": "array",
+                          "items": { "type": "string" },
+                          "default": []
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.emptyarray"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                Regex("""val DEFAULT_TAGS: List<\w+> = emptyList\(\)""").containsMatchIn(attributesContent),
+                "Expected DEFAULT_TAGS with emptyList() initializer"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate listOf for non-empty string array default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Non-Empty Array Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "defaultTags": {
+                          "title": "Default Tags",
+                          "type": "array",
+                          "items": { "type": "string" },
+                          "default": ["tag1", "tag2"]
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.nonemptyarray"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                attributesContent.contains("DEFAULT_DEFAULT_TAGS"),
+                "Non-empty string array default should generate DEFAULT_ constant"
+            )
+            assertTrue(
+                attributesContent.contains("listOf("),
+                "Non-empty string array default should use listOf()"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate listOf with enum values for non-empty enum array default`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Enum Array Default Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "enabledSeverities": {
+                          "title": "Enabled Severities",
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "enum": ["OK", "WARNING", "CRITICAL"]
+                          },
+                          "default": ["OK", "WARNING"]
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.enumarray"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                attributesContent.contains("DEFAULT_ENABLED_SEVERITIES"),
+                "Enum array default should generate DEFAULT_ constant"
+            )
+            assertTrue(
+                attributesContent.contains("EnabledSeveritiesItem"),
+                "Enum array default should reference the enum type"
+            )
+            assertTrue(
+                attributesContent.contains("listOf("),
+                "Enum array default should use listOf()"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should skip object enum default without name field`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Object Enum Missing Name Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "behavior": {
+                          "title": "Behavior",
+                          "type": "object",
+                          "enum": [
+                            { "name": "option1" },
+                            { "name": "option2" }
+                          ],
+                          "default": { "value": "something" }
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.missingname"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertFalse(
+                attributesContent.contains("DEFAULT_BEHAVIOR"),
+                "Object enum default without 'name' field should be skipped"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should convert camelCase property name to SCREAMING_SNAKE_CASE constant`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "CamelCase Property Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "maxRetryCount": {
+                          "title": "Max Retry Count",
+                          "type": "integer",
+                          "default": 3
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.camelcase"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+            assertTrue(
+                attributesContent.contains("DEFAULT_MAX_RETRY_COUNT"),
+                "Expected property name converted to SCREAMING_SNAKE_CASE"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `should generate multiple default constants in same companion object`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-default-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Multiple Defaults Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "isEnabled": {
+                          "title": "Is Enabled",
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "maxRetries": {
+                          "title": "Max Retries",
+                          "type": "integer",
+                          "default": 3
+                        },
+                        "temperature": {
+                          "title": "Temperature",
+                          "type": "number",
+                          "default": 22.5
+                        },
+                        "noDefault": {
+                          "title": "No Default",
+                          "type": "string"
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.defaulttest.multiple"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val attributesFile = outputDir.resolve("$packagePath/attributes/Attributes.kt")
+            val attributesContent = Files.readString(attributesFile)
+
+            assertTrue(attributesContent.contains("DEFAULT_IS_ENABLED"), "Expected DEFAULT_IS_ENABLED")
+            assertTrue(attributesContent.contains("DEFAULT_MAX_RETRIES"), "Expected DEFAULT_MAX_RETRIES")
+            assertTrue(attributesContent.contains("DEFAULT_TEMPERATURE"), "Expected DEFAULT_TEMPERATURE")
+            assertFalse(attributesContent.contains("DEFAULT_NO_DEFAULT"), "Should not have constant for property without default")
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    private fun deleteRecursively(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractorTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractorTest.kt
@@ -315,8 +315,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("isEnabled", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_IS_ENABLED", result!!.propertySpec.name)
-        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+        assertEquals("DEFAULT_IS_ENABLED", result!!.name)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
     }
 
     @Test
@@ -331,8 +331,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("maxRetries", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_MAX_RETRIES", result!!.propertySpec.name)
-        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+        assertEquals("DEFAULT_MAX_RETRIES", result!!.name)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
     }
 
     @Test
@@ -347,8 +347,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("temperature", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_TEMPERATURE", result!!.propertySpec.name)
-        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+        assertEquals("DEFAULT_TEMPERATURE", result!!.name)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
     }
 
     @Test
@@ -363,8 +363,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("status", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_STATUS", result!!.propertySpec.name)
-        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+        assertEquals("DEFAULT_STATUS", result!!.name)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
     }
 
     @Test
@@ -380,8 +380,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("createdAt", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_CREATED_AT", result!!.propertySpec.name)
-        assertFalse(result.propertySpec.modifiers.contains(KModifier.CONST)) // Instant is reference type
+        assertEquals("DEFAULT_CREATED_AT", result!!.name)
+        assertFalse(result.modifiers.contains(KModifier.CONST)) // Instant is reference type
     }
 
     @Test
@@ -397,8 +397,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("state", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_STATE", result!!.propertySpec.name)
-        assertFalse(result.propertySpec.modifiers.contains(KModifier.CONST)) // Enum is reference type
+        assertEquals("DEFAULT_STATE", result!!.name)
+        assertFalse(result.modifiers.contains(KModifier.CONST)) // Enum is reference type
     }
 
     @Test
@@ -414,8 +414,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("tags", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_TAGS", result!!.propertySpec.name)
-        assertFalse(result.propertySpec.modifiers.contains(KModifier.CONST)) // List is reference type
+        assertEquals("DEFAULT_TAGS", result!!.name)
+        assertFalse(result.modifiers.contains(KModifier.CONST)) // List is reference type
     }
 
     @Test
@@ -444,7 +444,7 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("tags", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        val spec = result!!.propertySpec
+        val spec = result!!
         assertFalse(spec.modifiers.contains(KModifier.CONST))
         assertEquals("DEFAULT_TAGS", spec.name)
         assertTrue(spec.initializer.toString().contains("listOf"))
@@ -497,8 +497,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("lowBatteryBehavior", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_LOW_BATTERY_BEHAVIOR", result!!.propertySpec.name)
-        assertFalse(result.propertySpec.modifiers.contains(KModifier.CONST))
+        assertEquals("DEFAULT_LOW_BATTERY_BEHAVIOR", result!!.name)
+        assertFalse(result.modifiers.contains(KModifier.CONST))
     }
 
     @Test
@@ -513,8 +513,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("isEnabled", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_IS_ENABLED", result!!.propertySpec.name)
-        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+        assertEquals("DEFAULT_IS_ENABLED", result!!.name)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
     }
 
     @Test
@@ -529,7 +529,7 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("name", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        assertEquals("DEFAULT_NAME", result!!.propertySpec.name)
+        assertEquals("DEFAULT_NAME", result!!.name)
     }
 
     @Test
@@ -557,8 +557,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
 
         assertEquals(2, result.size)
-        assertTrue(result.any { it.propertySpec.name == "DEFAULT_IS_ENABLED" })
-        assertTrue(result.any { it.propertySpec.name == "DEFAULT_MAX_RETRIES" })
+        assertTrue(result.any { it.name == "DEFAULT_IS_ENABLED" })
+        assertTrue(result.any { it.name == "DEFAULT_MAX_RETRIES" })
     }
 
     @Test
@@ -610,8 +610,8 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
 
         assertEquals(2, result.size)
-        assertTrue(result.any { it.propertySpec.name == "DEFAULT_TEMPERATURE" })
-        assertTrue(result.any { it.propertySpec.name == "DEFAULT_HUMIDITY" })
+        assertTrue(result.any { it.name == "DEFAULT_TEMPERATURE" })
+        assertTrue(result.any { it.name == "DEFAULT_HUMIDITY" })
     }
 
     @Test
@@ -723,7 +723,7 @@ class DefaultValueExtractorTest {
         val result = DefaultValueExtractor.extractDefaultFromSchema("enabledSeverities", schema, TEST_PACKAGE)
 
         assertNotNull(result)
-        val spec = result!!.propertySpec
+        val spec = result!!
         assertEquals("DEFAULT_ENABLED_SEVERITIES", spec.name)
         assertFalse(spec.modifiers.contains(KModifier.CONST))
         assertTrue(spec.initializer.toString().contains("listOf"))

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractorTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractorTest.kt
@@ -1,0 +1,732 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.util
+
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STRING
+import org.eclipse.ditto.json.JsonArray
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.model.SingleDataSchema
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [DefaultValueExtractor].
+ *
+ * Tests the extraction of `"default"` values from WoT Thing Model JSON-LD schemas
+ * and generation of corresponding `DEFAULT_*` companion object constants.
+ *
+ * @since 1.0.0
+ */
+class DefaultValueExtractorTest {
+
+    companion object {
+        private const val TEST_PACKAGE = "org.example.generated"
+    }
+
+    @Test
+    fun `should generate const val for boolean true default`() {
+        val constantName = "IS_ENABLED"
+        val value = true
+
+        val result = DefaultValueExtractor.createBooleanDefault(constantName, value)
+
+        assertEquals("DEFAULT_IS_ENABLED", result.name)
+        assertEquals(BOOLEAN, result.type)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("true"))
+    }
+
+    @Test
+    fun `should generate const val for boolean false default`() {
+        val constantName = "IS_DISABLED"
+        val value = false
+
+        val result = DefaultValueExtractor.createBooleanDefault(constantName, value)
+
+        assertEquals("DEFAULT_IS_DISABLED", result.name)
+        assertEquals(BOOLEAN, result.type)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("false"))
+    }
+
+    @Test
+    fun `should generate const val for integer default`() {
+        val constantName = "MAX_RETRIES"
+        val value = 3L
+
+        val result = DefaultValueExtractor.createIntegerDefault(constantName, value)
+
+        assertEquals("DEFAULT_MAX_RETRIES", result.name)
+        assertEquals(LONG, result.type)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("3"))
+    }
+
+    @Test
+    fun `should generate const val for integer zero default`() {
+        val constantName = "RETRY_COUNT"
+        val value = 0L
+
+        val result = DefaultValueExtractor.createIntegerDefault(constantName, value)
+
+        assertEquals("DEFAULT_RETRY_COUNT", result.name)
+        assertEquals(LONG, result.type)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("0"))
+    }
+
+    @Test
+    fun `should generate const val for negative integer default`() {
+        val constantName = "MIN_VALUE"
+        val value = -100L
+
+        val result = DefaultValueExtractor.createIntegerDefault(constantName, value)
+
+        assertEquals("DEFAULT_MIN_VALUE", result.name)
+        assertTrue(result.initializer.toString().contains("-100"))
+    }
+
+    @Test
+    fun `should generate const val for number default`() {
+        val constantName = "TEMPERATURE"
+        val value = 25.5
+
+        val result = DefaultValueExtractor.createNumberDefault(constantName, value)
+
+        assertEquals("DEFAULT_TEMPERATURE", result.name)
+        assertEquals(DOUBLE, result.type)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("25.5"))
+    }
+
+    @Test
+    fun `should generate const val for number zero default`() {
+        val constantName = "OFFSET"
+        val value = 0.0
+
+        val result = DefaultValueExtractor.createNumberDefault(constantName, value)
+
+        assertEquals("DEFAULT_OFFSET", result.name)
+        assertTrue(result.initializer.toString().contains("0.0"))
+    }
+
+    @Test
+    fun `should generate const val for string default`() {
+        val constantName = "DEFAULT_NAME"
+        val value = "unknown"
+
+        val result = DefaultValueExtractor.createStringDefault(constantName, value)
+
+        assertEquals("DEFAULT_DEFAULT_NAME", result.name)
+        assertEquals(STRING, result.type)
+        assertTrue(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("unknown"))
+    }
+
+    @Test
+    fun `should generate const val for empty string default`() {
+        val constantName = "LABEL"
+        val value = ""
+
+        val result = DefaultValueExtractor.createStringDefault(constantName, value)
+
+        assertEquals("DEFAULT_LABEL", result.name)
+        assertEquals(STRING, result.type)
+    }
+
+    @Test
+    fun `should generate val for instant default`() {
+        val constantName = "CREATED_AT"
+        val value = "2024-01-01T00:00:00Z"
+
+        val result = DefaultValueExtractor.createInstantDefault(constantName, value)
+
+        assertEquals("DEFAULT_CREATED_AT", result.name)
+        assertEquals(ClassName("java.time", "Instant"), result.type)
+        // Instant is a reference type, so no const modifier
+        assertFalse(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("Instant.parse"))
+        assertTrue(result.initializer.toString().contains("2024-01-01T00:00:00Z"))
+    }
+
+    @Test
+    fun `should generate val for enum default`() {
+        val constantName = "STATUS"
+        val enumTypeName = ClassName("", "Status")
+        val enumConstantValue = "active"
+        val enumName = "Status"
+
+        val result = DefaultValueExtractor.createEnumDefault(constantName, enumTypeName, enumConstantValue, enumName)
+
+        assertEquals("DEFAULT_STATUS", result.name)
+        assertEquals(ClassName("", "Status"), result.type)
+        // Enum is a reference type, so no const modifier
+        assertFalse(result.modifiers.contains(KModifier.CONST))
+        // Should use asEnumConstantName() to convert the value
+        assertTrue(result.initializer.toString().contains("Status.ACTIVE"))
+    }
+
+    @Test
+    fun `should generate val for enum default with special characters`() {
+        val constantName = "MODE"
+        val enumTypeName = ClassName("", "Mode")
+        val enumConstantValue = "low-power"
+        val enumName = "Mode"
+
+        val result = DefaultValueExtractor.createEnumDefault(constantName, enumTypeName, enumConstantValue, enumName)
+
+        assertEquals("DEFAULT_MODE", result.name)
+        // asEnumConstantName should handle the hyphen
+        assertTrue(result.initializer.toString().contains("Mode."))
+    }
+
+    @Test
+    fun `should generate val for object enum default`() {
+        val constantName = "BEHAVIOR"
+        val sealedTypeName = ClassName("", "LowBatteryBehavior")
+        val objectInstanceName = "SHUTDOWN"
+
+        val result = DefaultValueExtractor.createObjectEnumDefault(constantName, sealedTypeName, objectInstanceName)
+
+        assertEquals("DEFAULT_BEHAVIOR", result.name)
+        assertEquals(ClassName("", "LowBatteryBehavior"), result.type)
+        assertFalse(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("LowBatteryBehavior.SHUTDOWN"))
+    }
+
+    @Test
+    fun `should generate val for empty list default`() {
+        val constantName = "TAGS"
+        val elementType = STRING
+
+        val result = DefaultValueExtractor.createEmptyListDefault(constantName, elementType)
+
+        assertEquals("DEFAULT_TAGS", result.name)
+        assertEquals(LIST.parameterizedBy(STRING), result.type)
+        assertFalse(result.modifiers.contains(KModifier.CONST))
+        assertTrue(result.initializer.toString().contains("emptyList"))
+    }
+
+    @Test
+    fun `should generate val for empty list with object type`() {
+        val constantName = "ITEMS"
+        val elementType = ClassName("org.example", "Item")
+
+        val result = DefaultValueExtractor.createEmptyListDefault(constantName, elementType)
+
+        assertEquals("DEFAULT_ITEMS", result.name)
+        assertEquals(LIST.parameterizedBy(ClassName("org.example", "Item")), result.type)
+    }
+
+    @Test
+    fun `should detect string enum schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string",
+                "enum": ["active", "inactive"]
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.isStringEnum(schema)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should not detect non-enum string schema as string enum`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string"
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.isStringEnum(schema)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should detect object enum schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "object",
+                "enum": [{"name": "Option1"}, {"name": "Option2"}]
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.isObjectEnum(schema)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should detect date-time format schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string",
+                "format": "date-time"
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.isDateTimeFormat(schema)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should not detect non-datetime string as date-time format`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string"
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.isDateTimeFormat(schema)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should extract boolean default from schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "boolean",
+                "default": true
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("isEnabled", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_IS_ENABLED", result!!.propertySpec.name)
+        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+    }
+
+    @Test
+    fun `should extract integer default from schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "integer",
+                "default": 5
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("maxRetries", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_MAX_RETRIES", result!!.propertySpec.name)
+        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+    }
+
+    @Test
+    fun `should extract number default from schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "number",
+                "default": 22.5
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("temperature", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_TEMPERATURE", result!!.propertySpec.name)
+        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+    }
+
+    @Test
+    fun `should extract string default from schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string",
+                "default": "unknown"
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("status", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_STATUS", result!!.propertySpec.name)
+        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+    }
+
+    @Test
+    fun `should extract datetime default from schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string",
+                "format": "date-time",
+                "default": "2024-01-01T00:00:00Z"
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("createdAt", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_CREATED_AT", result!!.propertySpec.name)
+        assertFalse(result.propertySpec.modifiers.contains(KModifier.CONST)) // Instant is reference type
+    }
+
+    @Test
+    fun `should extract enum default from schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string",
+                "enum": ["active", "inactive", "pending"],
+                "default": "active"
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("state", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_STATE", result!!.propertySpec.name)
+        assertFalse(result.propertySpec.modifiers.contains(KModifier.CONST)) // Enum is reference type
+    }
+
+    @Test
+    fun `should extract empty array default from schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "array",
+                "items": { "type": "string" },
+                "default": []
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("tags", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_TAGS", result!!.propertySpec.name)
+        assertFalse(result.propertySpec.modifiers.contains(KModifier.CONST)) // List is reference type
+    }
+
+    @Test
+    fun `should return null for schema without default`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string"
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("status", schema, TEST_PACKAGE)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should generate listOf for non-empty string array default`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "array",
+                "items": { "type": "string" },
+                "default": ["tag1", "tag2"]
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("tags", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        val spec = result!!.propertySpec
+        assertFalse(spec.modifiers.contains(KModifier.CONST))
+        assertEquals("DEFAULT_TAGS", spec.name)
+        assertTrue(spec.initializer.toString().contains("listOf"))
+        assertTrue(spec.initializer.toString().contains("tag1"))
+        assertTrue(spec.initializer.toString().contains("tag2"))
+    }
+
+    @Test
+    fun `should skip nested object default silently`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                },
+                "default": { "name": "test" }
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("config", schema, TEST_PACKAGE)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should skip object enum default missing name field`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "object",
+                "enum": [{"name": "Option1"}, {"name": "Option2"}],
+                "default": { "value": "something" }
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("behavior", schema, TEST_PACKAGE)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should extract object enum default with name field`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "object",
+                "enum": [{"name": "Shutdown"}, {"name": "LowPower"}],
+                "default": { "name": "Shutdown" }
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("lowBatteryBehavior", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_LOW_BATTERY_BEHAVIOR", result!!.propertySpec.name)
+        assertFalse(result.propertySpec.modifiers.contains(KModifier.CONST))
+    }
+
+    @Test
+    fun `should extract default from schema with boolean type via extractDefaultFromSchema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "boolean",
+                "default": false
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("isEnabled", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_IS_ENABLED", result!!.propertySpec.name)
+        assertTrue(result.propertySpec.modifiers.contains(KModifier.CONST))
+    }
+
+    @Test
+    fun `should extract default from schema with string type via extractDefaultFromSchema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "string",
+                "default": "default_value"
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("name", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_NAME", result!!.propertySpec.name)
+    }
+
+    @Test
+    fun `should extract multiple default constants from schema fields`() {
+        val fields = mapOf(
+            "isEnabled" to SingleDataSchema.fromJson(JsonObject.of("""
+                {
+                    "type": "boolean",
+                    "default": true
+                }
+            """.trimIndent())),
+            "maxRetries" to SingleDataSchema.fromJson(JsonObject.of("""
+                {
+                    "type": "integer",
+                    "default": 3
+                }
+            """.trimIndent())),
+            "name" to SingleDataSchema.fromJson(JsonObject.of("""
+                {
+                    "type": "string"
+                }
+            """.trimIndent())) // No default
+        )
+
+        val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
+
+        assertEquals(2, result.size)
+        assertTrue(result.any { it.propertySpec.name == "DEFAULT_IS_ENABLED" })
+        assertTrue(result.any { it.propertySpec.name == "DEFAULT_MAX_RETRIES" })
+    }
+
+    @Test
+    fun `should return empty list when no fields have defaults`() {
+        val fields = mapOf(
+            "name" to SingleDataSchema.fromJson(JsonObject.of("""
+                {
+                    "type": "string"
+                }
+            """.trimIndent())),
+            "count" to SingleDataSchema.fromJson(JsonObject.of("""
+                {
+                    "type": "integer"
+                }
+            """.trimIndent()))
+        )
+
+        val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `should return empty list for empty fields map`() {
+        val fields = emptyMap<String, SingleDataSchema>()
+
+        val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `should extract default constants from number schema fields`() {
+        val fields = mapOf(
+            "temperature" to SingleDataSchema.fromJson(JsonObject.of("""
+                {
+                    "type": "number",
+                    "default": 22.5
+                }
+            """.trimIndent())),
+            "humidity" to SingleDataSchema.fromJson(JsonObject.of("""
+                {
+                    "type": "number",
+                    "default": 50.0
+                }
+            """.trimIndent()))
+        )
+
+        val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
+
+        assertEquals(2, result.size)
+        assertTrue(result.any { it.propertySpec.name == "DEFAULT_TEMPERATURE" })
+        assertTrue(result.any { it.propertySpec.name == "DEFAULT_HUMIDITY" })
+    }
+
+    @Test
+    fun `should use unqualified ClassName for inline enum types`() {
+        val constantName = "STATUS"
+        val enumTypeName = ClassName("", "Status") // Unqualified - empty package
+        val enumConstantValue = "ACTIVE"
+        val enumName = "Status"
+
+        val result = DefaultValueExtractor.createEnumDefault(constantName, enumTypeName, enumConstantValue, enumName)
+
+        assertEquals(ClassName("", "Status"), result.type)
+        // The generated code should work with both inline and standalone enums
+    }
+
+    @Test
+    fun `should create listOf for boolean array`() {
+        val array = JsonArray.of(true, false)
+
+        val result = DefaultValueExtractor.createListDefault("FLAGS", BOOLEAN, array, null, "flags")
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_FLAGS", result!!.name)
+        assertEquals(LIST.parameterizedBy(BOOLEAN), result.type)
+        assertTrue(result.initializer.toString().contains("listOf"))
+        assertTrue(result.initializer.toString().contains("true"))
+        assertTrue(result.initializer.toString().contains("false"))
+    }
+
+    @Test
+    fun `should create listOf for integer array`() {
+        val array = JsonArray.of(1, 2, 3)
+
+        val result = DefaultValueExtractor.createListDefault("COUNTS", LONG, array, null, "counts")
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_COUNTS", result!!.name)
+        assertEquals(LIST.parameterizedBy(LONG), result.type)
+        assertTrue(result.initializer.toString().contains("listOf"))
+    }
+
+    @Test
+    fun `should create listOf for double array`() {
+        val array = JsonArray.of(1.5, 2.0)
+
+        val result = DefaultValueExtractor.createListDefault("VALUES", DOUBLE, array, null, "values")
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_VALUES", result!!.name)
+        assertEquals(LIST.parameterizedBy(DOUBLE), result.type)
+        assertTrue(result.initializer.toString().contains("listOf"))
+        assertTrue(result.initializer.toString().contains("1.5"))
+    }
+
+    @Test
+    fun `should create listOf for string array`() {
+        val array = JsonArray.of("a", "b")
+
+        val result = DefaultValueExtractor.createListDefault("TAGS", STRING, array, null, "tags")
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_TAGS", result!!.name)
+        assertEquals(LIST.parameterizedBy(STRING), result.type)
+        assertTrue(result.initializer.toString().contains("listOf"))
+    }
+
+    @Test
+    fun `should create listOf for enum array`() {
+        val array = JsonArray.of("OK", "WARNING")
+        val enumType = ClassName("", "SeverityItem")
+        val enumValues = listOf("OK", "WARNING", "CRITICAL")
+
+        val result = DefaultValueExtractor.createListDefault("SEVERITIES", enumType, array, enumValues, "severities")
+
+        assertNotNull(result)
+        assertEquals("DEFAULT_SEVERITIES", result!!.name)
+        assertEquals(LIST.parameterizedBy(enumType), result.type)
+        assertTrue(result.initializer.toString().contains("SeverityItem"))
+    }
+
+    @Test
+    fun `should return null for unsupported element type in array`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "array",
+                "items": { "type": "object" },
+                "default": [{"key": "value"}]
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("items", schema, TEST_PACKAGE)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should extract enum array default from schema`() {
+        val schema = SingleDataSchema.fromJson(JsonObject.of("""
+            {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["OK", "WARNING", "CRITICAL"]
+                },
+                "default": ["OK", "WARNING"]
+            }
+        """.trimIndent()))
+
+        val result = DefaultValueExtractor.extractDefaultFromSchema("enabledSeverities", schema, TEST_PACKAGE)
+
+        assertNotNull(result)
+        val spec = result!!.propertySpec
+        assertEquals("DEFAULT_ENABLED_SEVERITIES", spec.name)
+        assertFalse(spec.modifiers.contains(KModifier.CONST))
+        assertTrue(spec.initializer.toString().contains("listOf"))
+        assertTrue(spec.initializer.toString().contains("EnabledSeveritiesItem"))
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractorTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/DefaultValueExtractorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test
  * Tests the extraction of `"default"` values from WoT Thing Model JSON-LD schemas
  * and generation of corresponding `DEFAULT_*` companion object constants.
  *
- * @since 1.0.0
+ * @since 1.1.0
  */
 class DefaultValueExtractorTest {
 
@@ -554,7 +554,7 @@ class DefaultValueExtractorTest {
             """.trimIndent())) // No default
         )
 
-        val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
+        val result = DefaultValueExtractor.extractDefaultConstants(fields, TEST_PACKAGE)
 
         assertEquals(2, result.size)
         assertTrue(result.any { it.name == "DEFAULT_IS_ENABLED" })
@@ -576,7 +576,7 @@ class DefaultValueExtractorTest {
             """.trimIndent()))
         )
 
-        val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
+        val result = DefaultValueExtractor.extractDefaultConstants(fields, TEST_PACKAGE)
 
         assertTrue(result.isEmpty())
     }
@@ -585,7 +585,7 @@ class DefaultValueExtractorTest {
     fun `should return empty list for empty fields map`() {
         val fields = emptyMap<String, SingleDataSchema>()
 
-        val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
+        val result = DefaultValueExtractor.extractDefaultConstants(fields, TEST_PACKAGE)
 
         assertTrue(result.isEmpty())
     }
@@ -607,7 +607,7 @@ class DefaultValueExtractorTest {
             """.trimIndent()))
         )
 
-        val result = DefaultValueExtractor.extractDefaultConstantsFromFields(fields, TEST_PACKAGE)
+        val result = DefaultValueExtractor.extractDefaultConstants(fields, TEST_PACKAGE)
 
         assertEquals(2, result.size)
         assertTrue(result.any { it.name == "DEFAULT_TEMPERATURE" })
@@ -631,7 +631,7 @@ class DefaultValueExtractorTest {
     fun `should create listOf for boolean array`() {
         val array = JsonArray.of(true, false)
 
-        val result = DefaultValueExtractor.createListDefault("FLAGS", BOOLEAN, array, null, "flags")
+        val result = DefaultValueExtractor.createListDefault("FLAGS", BOOLEAN, array, null)
 
         assertNotNull(result)
         assertEquals("DEFAULT_FLAGS", result!!.name)
@@ -645,7 +645,7 @@ class DefaultValueExtractorTest {
     fun `should create listOf for integer array`() {
         val array = JsonArray.of(1, 2, 3)
 
-        val result = DefaultValueExtractor.createListDefault("COUNTS", LONG, array, null, "counts")
+        val result = DefaultValueExtractor.createListDefault("COUNTS", LONG, array, null)
 
         assertNotNull(result)
         assertEquals("DEFAULT_COUNTS", result!!.name)
@@ -657,7 +657,7 @@ class DefaultValueExtractorTest {
     fun `should create listOf for double array`() {
         val array = JsonArray.of(1.5, 2.0)
 
-        val result = DefaultValueExtractor.createListDefault("VALUES", DOUBLE, array, null, "values")
+        val result = DefaultValueExtractor.createListDefault("VALUES", DOUBLE, array, null)
 
         assertNotNull(result)
         assertEquals("DEFAULT_VALUES", result!!.name)
@@ -670,7 +670,7 @@ class DefaultValueExtractorTest {
     fun `should create listOf for string array`() {
         val array = JsonArray.of("a", "b")
 
-        val result = DefaultValueExtractor.createListDefault("TAGS", STRING, array, null, "tags")
+        val result = DefaultValueExtractor.createListDefault("TAGS", STRING, array, null)
 
         assertNotNull(result)
         assertEquals("DEFAULT_TAGS", result!!.name)
@@ -684,7 +684,7 @@ class DefaultValueExtractorTest {
         val enumType = ClassName("", "SeverityItem")
         val enumValues = listOf("OK", "WARNING", "CRITICAL")
 
-        val result = DefaultValueExtractor.createListDefault("SEVERITIES", enumType, array, enumValues, "severities")
+        val result = DefaultValueExtractor.createListDefault("SEVERITIES", enumType, array, enumValues)
 
         assertNotNull(result)
         assertEquals("DEFAULT_SEVERITIES", result!!.name)


### PR DESCRIPTION
### Problem
WoT Thing Models enables us to configure "default" values for properties, but this information is lost during code generation. This enhancement exposes those defaults as typed companion object constants, enabling all users of the plugin to access and use default values however they need.

### Solution

- Add DefaultValueExtractor utility that reads "default" values from WoT Thing Model schemas and generates typed DEFAULT_* companion object constants in generated Kotlin classes
- Supports: boolean, integer, number, string, Instant, string enums, sealed class enums, empty arrays, and non-empty arrays of primitives/enums
- Works for both top-level and nested object properties (including deeply nested)

### Example
Given a WoT model propert:
` "enabled": { "type": "boolean", "default": true } `

Generated kotlin class will include
`companion object : HasPath {
 const val DEFAULT_ENABLED: Boolean = true
}`

No breaking change, default value should be merged with preexisting companion object. 