### PR TITLE
Add deprecation support for tm:submodel links

### DIFF
--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
@@ -158,9 +158,9 @@ object ClassGenerator {
      * @param links The WoT links containing feature definitions
      */
     suspend fun generateFeaturesClass(parentPackage: String, links: Iterable<BaseLink<*>>) {
-        val features = resolveFeatures(links, "$parentPackage.features")
+        val featuresWithDeprecation = resolveFeatures(links, "$parentPackage.features")
         val featuresPackage = "$parentPackage.features"
-        generateFeaturesClassFromFeatures(FEATURES_CLASS_NAME, features, featuresPackage)
+        generateFeaturesClassFromFeatures(FEATURES_CLASS_NAME, featuresWithDeprecation, featuresPackage)
     }
 
     /**
@@ -181,14 +181,14 @@ object ClassGenerator {
         val featuresPackage = "$packageName.features"
         val canonicalFeatureName = config?.featureName
             ?: asPropertyName(featureModel.title.get().toString())
-        val (featurePropertySpec, originalFeatureName) = generateSingleFeature(
+        val (featurePropertySpec, originalFeatureName, _) = generateSingleFeature(
             featureModel, canonicalFeatureName, featuresPackage
         )
         val featureClassName = asClassName(asPropertyName(originalFeatureName))
 
         generateFeaturesClassFromFeatures(
             "${featureClassName}Features",
-            listOf(Pair(featurePropertySpec, originalFeatureName)),
+            listOf(Triple(featurePropertySpec, originalFeatureName, null)),
             featuresPackage,
             originalName = "features"
         )
@@ -552,8 +552,9 @@ object ClassGenerator {
     private suspend fun generateSingleFeature(
         featureModel: ThingModel,
         originalFeatureName: String,
-        featuresPackageName: String
-    ): Pair<PropertySpec, String> {
+        featuresPackageName: String,
+        submodelDeprecationNotice: DeprecationNotice? = null
+    ): Triple<PropertySpec, String, DeprecationNotice?> {
         val propertyName = asPropertyName(originalFeatureName)
         val featurePackage = "$featuresPackageName.${asPackageName(originalFeatureName)}"
         val linkProperties = propertyResolver.resolveProperties(
@@ -568,23 +569,25 @@ object ClassGenerator {
         }
         generateFeatureClassFromProperties(
             originalFeatureName, asClassName(propertyName), featurePackage,
-            featureModel.properties.getOrNull(), featureModel.actions.getOrNull()
+            featureModel.properties.getOrNull(), featureModel.actions.getOrNull(), submodelDeprecationNotice
         )
-        return Pair(
+        return Triple(
             PropertySpec.builder(
                 propertyName, ClassName(featurePackage, asClassName(propertyName)).copy(nullable = true)
             ).mutable(true).initializer("null").build(),
-            originalFeatureName
+            originalFeatureName,
+            submodelDeprecationNotice
         )
     }
 
     private suspend fun resolveFeatures(
         links: Iterable<BaseLink<*>>,
         featuresPackageName: String
-    ): List<Pair<PropertySpec, String>> {
+    ): List<Triple<PropertySpec, String, DeprecationNotice?>> {
         return links.filter { LinkRelationType.isSubmodel(it) }.map {
             val featureModel = ThingModelGenerator.loadModel(it.href.toString())
-            generateSingleFeature(featureModel, getLinkInstanceName(it), featuresPackageName)
+            val submodelDeprecationNotice = extractDeprecationNotice(it)
+            generateSingleFeature(featureModel, getLinkInstanceName(it), featuresPackageName, submodelDeprecationNotice)
         }
     }
 
@@ -911,11 +914,11 @@ object ClassGenerator {
         }
     }
 
-    private fun generateFeaturesClassFromFeatures(className: String, properties: List<Pair<PropertySpec, String>>,
+    private fun generateFeaturesClassFromFeatures(className: String, properties: List<Triple<PropertySpec, String, DeprecationNotice?>>,
                                                   packageName: String, originalName: String? = null) {
         val featureDslFunsSpecs = properties.map {
             val propClassName = it.first.type as ClassName
-            dslGenerator.generateFeatureDslFunSpec(propClassName.simpleName, propClassName.packageName)
+            dslGenerator.generateFeatureDslFunSpec(propClassName.simpleName, propClassName.packageName, deprecationNotice = it.third)
         }
 
         val typeSpecBuilder = TypeSpec.classBuilder(className)
@@ -947,6 +950,9 @@ object ClassGenerator {
                     if (!hasJacksonAnnotation(it.first)) {
                         builder.addAnnotation(buildJsonPropertyAnnotationSpec(it.second))
                     }
+                    if (it.third?.deprecated == true) {
+                        builder.addAnnotation(buildDeprecatedAnnotationSpec(it.third!!))
+                    }
                     builder
                         .setter(provideExplicitSettoNullSetter(it.first))
                         .mutable(true)
@@ -972,7 +978,8 @@ object ClassGenerator {
         featureClassName: String,
         packageName: String,
         wotProperties: Properties?,
-        wotActions: Actions?
+        wotActions: Actions?,
+        submodelDeprecationNotice: DeprecationNotice? = null
     ) {
         val featurePropertiesClassName = featureClassName + "Properties"
         val featureClass = ClassName(packageName, featureClassName)
@@ -1005,6 +1012,10 @@ object ClassGenerator {
             .addSuperclassConstructorParameter("FEATURE_NAME")
             .addType(companionObject)
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
+
+        if (submodelDeprecationNotice?.deprecated == true) {
+            typeSpecBuilder.addAnnotation(buildDeprecatedAnnotationSpec(submodelDeprecationNotice))
+        }
 
         if (featurePropertiesClass == NOTHING) {
             typeSpecBuilder.addAnnotation(

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/AnnotationUtils.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/AnnotationUtils.kt
@@ -24,6 +24,7 @@ import org.eclipse.ditto.json.JsonPointer
 import org.eclipse.ditto.json.JsonValue
 import org.eclipse.ditto.wot.kotlin.generator.common.model.DittoJsonDsl
 import org.eclipse.ditto.wot.model.Action
+import org.eclipse.ditto.wot.model.BaseLink
 import org.eclipse.ditto.wot.model.Property
 import org.eclipse.ditto.wot.model.SingleDataSchema
 import kotlin.jvm.optionals.getOrNull
@@ -91,6 +92,8 @@ fun extractDeprecationNotice(property: Property): DeprecationNotice? = extractDe
 fun extractDeprecationNotice(action: Action): DeprecationNotice? = extractDeprecationNotice(action.toJson())
 
 fun extractDeprecationNotice(schema: SingleDataSchema): DeprecationNotice? = extractDeprecationNotice(schema.toJson())
+
+fun extractDeprecationNotice(link: BaseLink<*>): DeprecationNotice? = extractDeprecationNotice(link.toJson())
 
 fun extractDeprecationNotice(jsonObject: JsonObject): DeprecationNotice? {
     val deprecationNotice = jsonObject.getValue(JsonPointer.of(DITTO_DEPRECATION_NOTICE))

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DeprecationNoticeGenerationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DeprecationNoticeGenerationTest.kt
@@ -118,6 +118,108 @@ class DeprecationNoticeGenerationTest {
         }
     }
 
+    @Test
+    fun `deprecated submodel link generates kotlin deprecated annotations on feature class and DSL`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-deprecated-submodel-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": [
+                        "https://www.w3.org/2022/wot/td/v1.1",
+                        {
+                          "ditto": "https://ditto.eclipseprojects.io/wot/ditto-extension#"
+                        }
+                      ],
+                      "@type": "tm:ThingModel",
+                      "title": "Deprecated Submodel Demo",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "name": {
+                          "title": "Name",
+                          "type": "string"
+                        }
+                      },
+                      "links": [
+                        {
+                          "rel": "tm:submodel",
+                          "href": "https://eclipse-ditto.github.io/ditto-examples/wot/models/dimmable-colored-lamp-1.0.0.tm.jsonld",
+                          "type": "application/tm+json",
+                          "instanceName": "Spot1",
+                          "ditto:deprecationNotice": {
+                            "deprecated": true,
+                            "removalVersion": "2.0.0"
+                          }
+                        },
+                        {
+                          "rel": "tm:submodel",
+                          "href": "https://eclipse-ditto.github.io/ditto-examples/wot/models/connection-status-1.0.0.tm.jsonld",
+                          "type": "application/tm+json",
+                          "instanceName": "ConnectionStatus"
+                        }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.deprecatedsubmodeltest"
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val featuresFile = outputDir.resolve("$packagePath/features/Features.kt")
+            val spot1FeatureFile = outputDir.resolve("$packagePath/features/spot1/Spot1.kt")
+            val connectionStatusFeatureFile = outputDir.resolve("$packagePath/features/connectionstatus/ConnectionStatus.kt")
+
+            assertTrue(Files.exists(featuresFile), "Expected generated Features file at: $featuresFile")
+            assertTrue(Files.exists(spot1FeatureFile), "Expected generated Spot1 feature file at: $spot1FeatureFile")
+            assertTrue(Files.exists(connectionStatusFeatureFile), "Expected generated ConnectionStatus feature file at: $connectionStatusFeatureFile")
+
+            val featuresContent = Files.readString(featuresFile)
+            val spot1Content = Files.readString(spot1FeatureFile)
+            val connectionStatusContent = Files.readString(connectionStatusFeatureFile)
+
+            // The deprecated submodel feature class should have @Deprecated annotation
+            assertTrue(
+                spot1Content.contains("@Deprecated("),
+                "Expected Spot1 feature class to have @Deprecated annotation. Generated content:\n$spot1Content"
+            )
+            assertTrue(
+                spot1Content.contains("Will be removed in version 2.0.0."),
+                "Expected Spot1 @Deprecated annotation to contain removal version. Generated content:\n$spot1Content"
+            )
+
+            // The deprecated feature property in Features class should have @Deprecated annotation
+            assertTrue(
+                Regex("(?s)@Deprecated\\(.*2\\.0\\.0.*\\)\\s*(public\\s+)?(override\\s+)?var spot1")
+                    .containsMatchIn(featuresContent),
+                "Expected spot1 property in Features to be annotated as deprecated. Generated content:\n$featuresContent"
+            )
+
+            // The deprecated feature DSL function in Features class should have @Deprecated annotation
+            assertTrue(
+                Regex("(?s)@Deprecated\\(.*2\\.0\\.0.*\\)\\s*(public\\s+)?(suspend\\s+)?fun spot1\\(")
+                    .containsMatchIn(featuresContent),
+                "Expected spot1 DSL builder function in Features to be annotated as deprecated. Generated content:\n$featuresContent"
+            )
+
+            // The non-deprecated feature should NOT have @Deprecated annotation
+            assertTrue(
+                !connectionStatusContent.contains("@Deprecated("),
+                "Expected ConnectionStatus feature class to NOT have @Deprecated annotation. Generated content:\n$connectionStatusContent"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
     private fun deleteRecursively(path: Path) {
         if (!Files.exists(path)) return
         Files.walk(path)

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/OpenApiGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/OpenApiGenerator.kt
@@ -15,6 +15,7 @@ package org.eclipse.ditto.wot.openapi.generator
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Paths
 import org.eclipse.ditto.wot.model.ThingModel
+import org.eclipse.ditto.wot.openapi.generator.Utils.DeprecationNotice
 
 /**
  * Interface for generating OpenAPI specifications from Web of Things (WoT) Thing models.
@@ -67,15 +68,16 @@ interface OpenApiGenerator {
      * @param paths The OpenAPI paths object to add generated paths to
      * @param openAPI The OpenAPI instance for schema registration
      */
-    fun generateFeaturePaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI)
-    
+    fun generateFeaturePaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI, submodelDeprecationNotice: DeprecationNotice? = null)
+
     /**
      * Generates OpenAPI paths for feature actions operations.
-     * 
+     *
      * @param featureName The name of the feature
      * @param featureModel The WoT Thing model representing the feature
      * @param paths The OpenAPI paths object to add generated paths to
      * @param openAPI The OpenAPI instance for schema registration
+     * @param submodelDeprecationNotice Optional deprecation notice from the submodel link
      */
-    fun generateFeatureActionsPaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI)
+    fun generateFeatureActionsPaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI, submodelDeprecationNotice: DeprecationNotice? = null)
 }

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/OpenApiGeneratorImpl.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/OpenApiGeneratorImpl.kt
@@ -15,6 +15,7 @@ package org.eclipse.ditto.wot.openapi.generator
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Paths
 import org.eclipse.ditto.wot.model.ThingModel
+import org.eclipse.ditto.wot.openapi.generator.Utils.DeprecationNotice
 import org.eclipse.ditto.wot.openapi.generator.features.FeatureActionsPathsGenerator
 import org.eclipse.ditto.wot.openapi.generator.features.FeatureSchemaResolver
 import org.eclipse.ditto.wot.openapi.generator.features.FeaturesPathsGenerator
@@ -105,21 +106,22 @@ object OpenApiGeneratorImpl : OpenApiGenerator {
      * @param paths The OpenAPI paths object to add generated paths to
      * @param openAPI The OpenAPI instance for schema registration
      */
-    override fun generateFeaturePaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI) {
-        featuresPathsGenerator.generateFeaturesPaths(featureName, featureModel, paths, openAPI)
+    override fun generateFeaturePaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI, submodelDeprecationNotice: DeprecationNotice?) {
+        featuresPathsGenerator.generateFeaturesPaths(featureName, featureModel, paths, openAPI, submodelDeprecationNotice)
     }
 
     /**
      * Generates OpenAPI paths for feature actions operations.
      * Delegates to the FeatureActionsPathsGenerator for path generation.
-     * 
+     *
      * @param featureName The name of the feature
      * @param featureModel The WoT Thing model representing the feature
      * @param paths The OpenAPI paths object to add generated paths to
      * @param openAPI The OpenAPI instance for schema registration
+     * @param submodelDeprecationNotice Optional deprecation notice from the submodel link
      */
-    override fun generateFeatureActionsPaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI) {
-        featuresActionsPathsGenerator.generateFeatureActionsPaths(featureName, featureModel, paths, openAPI)
+    override fun generateFeatureActionsPaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI, submodelDeprecationNotice: DeprecationNotice?) {
+        featuresActionsPathsGenerator.generateFeatureActionsPaths(featureName, featureModel, paths, openAPI, submodelDeprecationNotice)
     }
 }
 

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/Utils.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/Utils.kt
@@ -18,6 +18,7 @@ import org.eclipse.ditto.json.JsonObject
 import org.eclipse.ditto.json.JsonPointer
 import org.eclipse.ditto.json.JsonValue
 import org.eclipse.ditto.wot.model.Action
+import org.eclipse.ditto.wot.model.BaseLink
 import org.eclipse.ditto.wot.model.DataSchemaType
 import org.eclipse.ditto.wot.model.MultipleDataSchema
 import org.eclipse.ditto.wot.model.Property
@@ -411,6 +412,13 @@ object Utils {
      */
     fun extractDeprecationNotice(action: Action): DeprecationNotice? {
         return extractDeprecationNotice(action.toJson())
+    }
+
+    /**
+     * Extracts the Ditto deprecation notice from a WoT link (e.g. a tm:submodel link).
+     */
+    fun extractDeprecationNotice(link: BaseLink<*>): DeprecationNotice? {
+        return extractDeprecationNotice(link.toJson())
     }
 
     /**

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/WotLoader.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/WotLoader.kt
@@ -130,10 +130,12 @@ object WotLoader {
 
         runBlocking {
             val featureModels = getSubModels(links)
-            openAPI.schema("features", featureSchemaResolver.resolveCompleteFeaturesSchema(featureModels, openAPI))
+            openAPI.schema("features", featureSchemaResolver.resolveCompleteFeaturesSchema(
+                featureModels.map { it.first to it.second }, openAPI))
             featureModels.forEach {
                 val featureName = it.first
                 val featureModel = it.second
+                val deprecationNotice = it.third
                 val featureTitle = featureModel.title.getOrNull()?.toString() ?: featureName
                 val tag = Tag()
                     .name("Feature: $featureTitle")
@@ -150,8 +152,8 @@ object WotLoader {
                     }
                 }
                 generator.generateFeatureOpenApi(featureName, featureModel, openAPI)
-                generator.generateFeaturePaths(featureName, featureModel, paths, openAPI)
-                generator.generateFeatureActionsPaths(featureName, featureModel, paths, openAPI)
+                generator.generateFeaturePaths(featureName, featureModel, paths, openAPI, deprecationNotice)
+                generator.generateFeatureActionsPaths(featureName, featureModel, paths, openAPI, deprecationNotice)
             }
         }
 
@@ -242,15 +244,16 @@ object WotLoader {
      */
     suspend fun getSubModels(
         links: Iterable<BaseLink<*>>
-    ): List<Pair<String, ThingModel>> {
+    ): List<Triple<String, ThingModel, Utils.DeprecationNotice?>> {
         return links.filter { isSubmodel(it) }.map {
             val instanceName = it.toJson().getValue("instanceName").getOrNull()?.asString()!!
             val submodel = loadModelFromUrl(it.href.toString())
+            val deprecationNotice = Utils.extractDeprecationNotice(it)
 
             val submodelLinks = submodel.links.getOrNull() ?: emptyList<BaseLink<*>>()
             validateTmExtendsLinks(submodelLinks)
 
-            instanceName to submodel
+            Triple(instanceName, submodel, deprecationNotice)
         }
     }
 

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeatureActionsPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeatureActionsPathsGenerator.kt
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.models.responses.ApiResponses
 import org.eclipse.ditto.wot.model.Action
 import org.eclipse.ditto.wot.model.ThingModel
 import org.eclipse.ditto.wot.openapi.generator.Utils.asOpenApiSchema
+import org.eclipse.ditto.wot.openapi.generator.Utils.DeprecationNotice
 import org.eclipse.ditto.wot.openapi.generator.Utils.extractDeprecationNotice
 import org.eclipse.ditto.wot.openapi.generator.Utils.mergeWithDeprecationNotice
 import org.eclipse.ditto.wot.openapi.generator.providers.ApiResponsesProvider
@@ -38,19 +39,20 @@ object FeatureActionsPathsGenerator {
 
     var apiResponsesProvider: ApiResponsesProvider = ApiResponsesProvider
 
-    fun generateFeatureActionsPaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI) {
+    fun generateFeatureActionsPaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI, submodelDeprecationNotice: DeprecationNotice? = null) {
         val featureTitle = featureModel.title.getOrNull()?.toString() ?: featureName
         val featureActions = featureModel.actions.getOrNull()
         featureActions?.entries?.sortedBy { it.key }?.map {
             paths.addPathItem(
                 "/{thingId}/features/$featureName/inbox/messages/${it.key}",
-                providePathForAction(featureTitle, featureName, it.value, openAPI)
+                providePathForAction(featureTitle, featureName, it.value, openAPI, submodelDeprecationNotice)
             )
         }
     }
 
-    private fun providePathForAction(featureTitle: String, featureName: String, action: Action, openAPI: OpenAPI): PathItem {
-        val deprecationNotice = extractDeprecationNotice(action)
+    private fun providePathForAction(featureTitle: String, featureName: String, action: Action, openAPI: OpenAPI, submodelDeprecationNotice: DeprecationNotice? = null): PathItem {
+        val actionDeprecationNotice = extractDeprecationNotice(action)
+        val deprecationNotice = actionDeprecationNotice ?: submodelDeprecationNotice
         val deprecated = deprecationNotice?.deprecated == true
 
         val operation = Operation()

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeaturesPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeaturesPathsGenerator.kt
@@ -24,8 +24,11 @@ import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.responses.ApiResponses
 import org.eclipse.ditto.wot.model.Property
 import org.eclipse.ditto.wot.model.ThingModel
+import org.eclipse.ditto.wot.openapi.generator.Utils
+import org.eclipse.ditto.wot.openapi.generator.Utils.DeprecationNotice
 import org.eclipse.ditto.wot.openapi.generator.Utils.asOpenApiSchema
 import org.eclipse.ditto.wot.openapi.generator.Utils.asPropertyName
+import org.eclipse.ditto.wot.openapi.generator.Utils.buildDeprecationDescription
 import org.eclipse.ditto.wot.openapi.generator.Utils.extractDeprecationNotice
 import org.eclipse.ditto.wot.openapi.generator.Utils.extractPropertyCategory
 import org.eclipse.ditto.wot.openapi.generator.Utils.isPrimitive
@@ -42,10 +45,11 @@ object FeaturesPathsGenerator {
 
     var apiResponsesProvider: ApiResponsesProvider = ApiResponsesProvider
 
-    fun generateFeaturesPaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI) {
+    fun generateFeaturesPaths(featureName: String, featureModel: ThingModel, paths: Paths, openAPI: OpenAPI, submodelDeprecationNotice: DeprecationNotice? = null) {
         val featurePropertiesModels = featureModel.properties.getOrNull()
         val featureTitle = featureModel.title.getOrNull()?.toString() ?: featureName
-        paths.putAll(providePathItemsForFeature(featureName, featureTitle))
+        val submodelDeprecated = submodelDeprecationNotice?.deprecated == true
+        paths.putAll(providePathItemsForFeature(featureName, featureTitle, submodelDeprecated, submodelDeprecationNotice))
 
         featurePropertiesModels?.entries
             ?.sortedBy { extractPropertyCategory(it.value) + it.key }
@@ -54,22 +58,28 @@ object FeaturesPathsGenerator {
                 if (dittoCategory != null && !paths.containsKey("/{thingId}/features/$featureName/properties/$dittoCategory")) {
                     paths.addPathItem(
                         "/{thingId}/features/$featureName/properties/$dittoCategory",
-                        providePathItemFeaturePropertiesCategory(featureName, featureTitle, dittoCategory)
+                        providePathItemFeaturePropertiesCategory(featureName, featureTitle, dittoCategory, submodelDeprecationNotice)
                     )
                 }
                 paths.addPathItem("/{thingId}/features/$featureName/properties/${dittoCategory?.let { "$it/" } ?: ""}${it.key}",
-                    providePathItemFeatureProperty(featureName, featureTitle, it.value, openAPI))
+                    providePathItemFeatureProperty(featureName, featureTitle, it.value, openAPI, submodelDeprecationNotice))
             }
     }
 
     private fun providePathItemFeaturePropertiesCategory(
         featureName: String,
         featureTitle: String,
-        category: String
-    ): PathItem = PathItem()
+        category: String,
+        submodelDeprecationNotice: DeprecationNotice? = null
+    ): PathItem {
+        val deprecated = submodelDeprecationNotice?.deprecated == true
+        val deprecationDescription = buildDeprecationDescription(submodelDeprecationNotice)
+        return PathItem()
         .get(
             Operation()
+                .also { if (deprecated) it.deprecated(true) }
                 .summary("Retrieves all '$category' categorized properties of feature $featureTitle")
+                .description(deprecationDescription)
                 .tags(listOf("Feature: $featureTitle"))
                 .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
                 .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_FIELDS) })
@@ -91,13 +101,17 @@ object FeaturesPathsGenerator {
                         .addApiResponse(apiResponsesProvider.provide401ApiResponse("features/$featureName/properties/$category"))
                 )
         )
+    }
 
-    private fun providePathItemsForFeature(featureName: String, featureTitle: String): Map<String, PathItem> {
+    private fun providePathItemsForFeature(featureName: String, featureTitle: String, deprecated: Boolean = false, deprecationNotice: DeprecationNotice? = null): Map<String, PathItem> {
+        val deprecationDescription = buildDeprecationDescription(deprecationNotice)
         return mapOf(
             "/{thingId}/features/$featureName" to PathItem()
                 .get(
                     Operation()
+                        .also { if (deprecated) it.deprecated(true) }
                         .summary("Retrieves the feature $featureTitle")
+                        .description(deprecationDescription)
                         .tags(listOf("Feature: $featureTitle"))
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_FIELDS) })
@@ -126,11 +140,13 @@ object FeaturesPathsGenerator {
         featureName: String,
         featureTitle: String,
         property: Property,
-        openAPI: OpenAPI
+        openAPI: OpenAPI,
+        submodelDeprecationNotice: DeprecationNotice? = null
     ): PathItem {
 
         val dittoCategory = extractPropertyCategory(property)
-        val deprecationNotice = extractDeprecationNotice(property)
+        val propertyDeprecationNotice = extractDeprecationNotice(property)
+        val deprecationNotice = propertyDeprecationNotice ?: submodelDeprecationNotice
         val deprecated = deprecationNotice?.deprecated == true
         val description = mergeWithDeprecationNotice(property.description.getOrNull()?.toString(), deprecationNotice)
         val responseSchema = provideSchema(property, featureName, openAPI)

--- a/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
+++ b/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
@@ -350,6 +350,133 @@ class DeprecationNoticeAndPathsTest {
         assertContains(actionDescription, "2.0.0")
     }
 
+    @Test
+    fun `deprecated submodel link marks all feature operations as deprecated`() {
+        val featureModel = thingModelFromJson(
+            """
+            {
+              "@context": [
+                "https://www.w3.org/2022/wot/td/v1.1",
+                { "ditto": "https://ditto.eclipseprojects.io/wot/ditto-extension#" }
+              ],
+              "@type": "tm:ThingModel",
+              "title": "Battery",
+              "properties": {
+                "voltage": {
+                  "title": "Voltage",
+                  "type": "number",
+                  "ditto:category": "status"
+                }
+              },
+              "actions": {
+                "calibrate": {
+                  "title": "Calibrate",
+                  "input": { "type": "string" }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        val submodelDeprecation = Utils.DeprecationNotice(deprecated = true, removalVersion = "2.0.0")
+
+        FeaturesPathsGenerator.generateFeaturesPaths("battery", featureModel, paths, api, submodelDeprecation)
+        FeatureActionsPathsGenerator.generateFeatureActionsPaths("battery", featureModel, paths, api, submodelDeprecation)
+
+        // Feature-level GET should be deprecated
+        val featurePath = paths["/{thingId}/features/battery"]
+        assertTrue(featurePath?.get?.deprecated == true)
+        assertNotNull(featurePath?.get?.description)
+        assertContains(featurePath!!.get.description, "**Deprecated.**")
+        assertContains(featurePath.get.description, "2.0.0")
+
+        // Category path should inherit submodel deprecation
+        val categoryPath = paths["/{thingId}/features/battery/properties/status"]
+        assertTrue(categoryPath?.get?.deprecated == true)
+        assertNotNull(categoryPath?.get?.description)
+        assertContains(categoryPath!!.get.description, "**Deprecated.**")
+        assertContains(categoryPath.get.description, "2.0.0")
+
+        // Property operations should inherit submodel deprecation
+        val propertyPath = paths["/{thingId}/features/battery/properties/status/voltage"]
+        assertTrue(propertyPath?.get?.deprecated == true)
+        assertContains(propertyPath!!.get.description!!, "**Deprecated.**")
+
+        // Action operations should inherit submodel deprecation
+        val actionPost = paths["/{thingId}/features/battery/inbox/messages/calibrate"]?.post
+        assertTrue(actionPost?.deprecated == true)
+        assertContains(actionPost!!.description!!, "**Deprecated.**")
+    }
+
+    @Test
+    fun `property-level deprecation takes precedence over submodel-level deprecation`() {
+        val featureModel = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Battery",
+              "properties": {
+                "voltage": {
+                  "title": "Voltage",
+                  "type": "number",
+                  "ditto:deprecationNotice": {
+                    "deprecated": true,
+                    "supersededBy": "#/properties/batteryLevel",
+                    "removalVersion": "3.0.0"
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        val submodelDeprecation = Utils.DeprecationNotice(deprecated = true, removalVersion = "2.0.0")
+
+        FeaturesPathsGenerator.generateFeaturesPaths("battery", featureModel, paths, api, submodelDeprecation)
+
+        // Property has its own deprecation notice - should use that (3.0.0), not the submodel one (2.0.0)
+        val propertyPath = paths["/{thingId}/features/battery/properties/voltage"]
+        assertTrue(propertyPath?.get?.deprecated == true)
+        assertContains(propertyPath!!.get.description!!, "3.0.0")
+        assertContains(propertyPath.get.description!!, "#/properties/batteryLevel")
+    }
+
+    @Test
+    fun `non-deprecated submodel does not mark feature operations as deprecated`() {
+        val featureModel = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Battery",
+              "properties": {
+                "voltage": {
+                  "title": "Voltage",
+                  "type": "number"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+
+        // No submodel deprecation notice (null)
+        FeaturesPathsGenerator.generateFeaturesPaths("battery", featureModel, paths, api)
+
+        val featurePath = paths["/{thingId}/features/battery"]
+        assertNull(featurePath?.get?.deprecated)
+
+        val propertyPath = paths["/{thingId}/features/battery/properties/voltage"]
+        assertNull(propertyPath?.get?.deprecated)
+    }
+
     private fun thingModelFromJson(json: String): ThingModel =
         ThingModel.fromJson(JsonObject.of(json))
 


### PR DESCRIPTION
- Support `ditto:deprecationNotice` on `tm:submodel` links, in addition to the existing support on properties and actions
  - **OpenAPI generator**: all endpoints under a deprecated feature (feature path, category  path, property paths, action paths) are marked `deprecated: true` with a description.   
 Property/action-level deprecation takes precedence over submodel-level.
  - **Kotlin generator**: the feature class gets `@Deprecated`, and the feature property + DSL builder in the `Features` class get `@Deprecated`. Inner properties/actions are not  marked since they're only reachable through the already-deprecated feature entry point.