### PR TITLE
Add deduplicateReferencedTypes config option

### DIFF
--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/README.md
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/README.md
@@ -84,6 +84,7 @@ The WoT Kotlin Generator consists of two Maven modules:
 | `generateSuspendDsl` | boolean | No | `false` | Whether DSL functions should be suspend functions                        |
 | `submodelOnly` | boolean | No | `false` | Generate a self-contained submodel package instead of a full device model |
 | `featureName` | String | No | _(camelCase of model title)_ | JSON key for the feature when using `submodelOnly`                       |
+| `deduplicateReferencedTypes` | boolean | No | `false` | Collapse identical types shared via `tm:ref` into a single generated class |
 
 
 ## Submodel-Only Mode
@@ -208,6 +209,65 @@ Uses original schema titles when possible, falls back to compound naming for con
 - Shorter, more readable names when possible
 - Maintains original schema naming intent
 - Automatic conflict resolution
+
+### Type Deduplication
+
+When a WoT Thing Model reuses the same type definition across multiple features via `tm:ref`, the generator normally creates a separate class for each occurrence. With `deduplicateReferencedTypes=true`, identical types are collapsed into a single generated class, and all other occurrences reference it via import.
+
+#### How It Works
+
+The generator uses a two-phase approach:
+
+1. **Pre-scan phase**: Before code generation, the generator scans the Thing Model JSON to discover all `tm:ref` URLs and their target schemas. It records:
+   - A fingerprint of each referenced schema (for content-based matching)
+   - The `title` field from each referenced schema (for naming)
+   - How many properties reference each `tm:ref` URL
+
+2. **Generation phase**: When generating a class for a property, the generator checks:
+   - Has this `tm:ref` URL already been generated? If so, reuse that class.
+   - Does the schema JSON match a previously generated class? If so, reuse it.
+   - Otherwise, generate a new class and register it for future reuse.
+
+#### Title-Based Naming
+
+When dedup is enabled and a `tm:ref` is referenced by multiple properties, the generator uses the **title from the referenced schema** as the class name instead of the first property name. This avoids misleading names when multiple properties share the same type definition.
+
+Falls back to the property name if:
+- Only one property references the `tm:ref` (no ambiguity)
+- The title would produce the same class name as the property name (no benefit)
+- Two distinct `tm:ref` targets would produce the same class name (conflict)
+
+#### Configuration
+
+```xml
+<configuration>
+    <thingModelUrl>https://example.org/thing-model.jsonld</thingModelUrl>
+    <packageName>com.example.iot</packageName>
+    <deduplicateReferencedTypes>true</deduplicateReferencedTypes>
+</configuration>
+```
+
+#### What to Expect
+
+With dedup **disabled** (default):
+- Each feature gets its own copy of shared types
+- Class names are derived from the property name in each feature
+- No cross-feature imports
+
+With dedup **enabled**:
+- Shared types are generated once in the first feature that uses them
+- Other features import the shared type instead of generating a duplicate
+- Class names for multi-referenced types use the `tm:ref` target's title
+- File count decreases (the reduction depends on how many types are shared in the model)
+
+#### Interaction with Other Settings
+
+| Setting | Effect with Dedup |
+|---------|-------------------|
+| `COMPOUND_ALL` | Shared types use compound names from the first feature, others import |
+| `ORIGINAL_THEN_COMPOUND` | Shared types use the schema title when possible, resulting in shorter names |
+| `INLINE` | Enum dedup works within inline enums — identical enums are generated once |
+| `SEPARATE_CLASS` | Separate enum files are deduplicated — identical enums in different packages import the canonical one |
 
 ### DSL Configuration
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/GeneratorStarter.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/GeneratorStarter.kt
@@ -14,6 +14,7 @@ package org.eclipse.ditto.wot.kotlin.generator.plugin
 
 import kotlinx.coroutines.runBlocking
 import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
+import org.eclipse.ditto.wot.kotlin.generator.plugin.property.TmRefScanner
 import org.slf4j.LoggerFactory
 import kotlin.system.exitProcess
 
@@ -32,7 +33,7 @@ import kotlin.system.exitProcess
 object GeneratorStarter {
 
     private val thingModelGenerator = ThingModelGenerator
-    private val logger = LoggerFactory.getLogger(ThingModelGenerator::class.java)
+    private val logger = LoggerFactory.getLogger(GeneratorStarter::class.java)
 
     /**
      * Runs the generator with command-line arguments.
@@ -64,7 +65,7 @@ object GeneratorStarter {
             return 1
         }
 
-        logger.info("-----> Starting generator with args: $modelUrl, $packageName, $outputDir")
+        logger.debug("Starting generator with args: $modelUrl, $packageName, $outputDir")
 
         // Create default configuration for backward compatibility
         val defaultConfig = GeneratorConfiguration(
@@ -90,9 +91,18 @@ object GeneratorStarter {
      */
     @Throws(Exception::class)
     fun run(config: GeneratorConfiguration): Int {
-        logger.info("-----> Starting generator with configuration: ${config.enumGenerationStrategy}")
+        logger.info("Starting generator with strategy: ${config.enumGenerationStrategy}, dedup: ${config.deduplicateReferencedTypes}")
         return try {
             runBlocking {
+                if (config.deduplicateReferencedTypes) {
+                    try {
+                        logger.info("Pre-scanning tm:ref URLs from ${config.thingModelUrl}")
+                        TmRefScanner.scan(config.thingModelUrl)
+                        logger.info("Pre-scan complete")
+                    } catch (e: Exception) {
+                        logger.warn("tm:ref pre-scan failed (dedup will fall back to schema comparison): ${e.message}")
+                    }
+                }
                 val thingModel = thingModelGenerator.loadModel(config.thingModelUrl)
                 thingModelGenerator.generate(thingModel, config)
             }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/ThingModelGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/ThingModelGenerator.kt
@@ -15,6 +15,9 @@ package org.eclipse.ditto.wot.kotlin.generator.plugin
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.ClassGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.ClassRegistry
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.EnumRegistry
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.SharedTypeRegistry
 import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
 import org.eclipse.ditto.wot.kotlin.generator.plugin.loader.DittoBasedWotLoader
 import org.eclipse.ditto.wot.kotlin.generator.plugin.strategy.EnumGenerationStrategyFactory
@@ -102,13 +105,22 @@ object ThingModelGenerator {
      * @param config The configuration controlling the generation process
      */
     suspend fun generate(thingModel: ThingModel, config: GeneratorConfiguration) {
-        logger.info("Using enum generation strategy: ${config.enumGenerationStrategy}")
-        logger.info("Generate DSL: ${config.generateDsl}")
-        logger.info("Generate Enums: ${config.generateEnums}")
-        logger.info("Generate Interfaces: ${config.generateInterfaces}")
+        logger.debug("Using enum generation strategy: ${config.enumGenerationStrategy}")
+        logger.debug("Generate DSL: ${config.generateDsl}")
+        logger.debug("Generate Enums: ${config.generateEnums}")
+        logger.debug("Generate Interfaces: ${config.generateInterfaces}")
 
         classGenerator.setOutputDir(config.outputDirectory.path)
         classGenerator.setEnumGenerationStrategy(config)
+
+        // Clear all registries at the start of each generation run to prevent stale state
+        // from a previous model leaking into the current one in multi-execution builds.
+        ClassRegistry.clear()
+        EnumRegistry.clear()
+        if (config.deduplicateReferencedTypes) {
+            logger.info("Type deduplication enabled: types from the same tm:ref will be generated once (first encounter wins)")
+            SharedTypeRegistry.clear()
+        }
 
         // Set enum generation strategy in WrapperTypeChecker
         val enumStrategy = EnumGenerationStrategyFactory.createStrategy(config)

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/WotKotlinCodegenMojo.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/WotKotlinCodegenMojo.kt
@@ -106,6 +106,12 @@ class WotKotlinCodegenMojo: AbstractMojo() {
     @Parameter(property = "featureName")
     var featureName: String? = null
 
+    /**
+     * When true, types from the same tm:ref URL are generated only once.
+     * The first encounter determines the name and package; subsequent uses reuse it.
+     */
+    @Parameter(property = "deduplicateReferencedTypes", defaultValue = "false")
+    var deduplicateReferencedTypes: Boolean = false
 
     /**
      * Main execution method called by Maven during the build lifecycle.
@@ -134,27 +140,22 @@ class WotKotlinCodegenMojo: AbstractMojo() {
         try {
             // Create configuration with new parameters
             val config = createConfiguration(thingModelUrl!!, packageN, output)
-            log.info("---> Using enum generation strategy: ${config.enumGenerationStrategy}")
-            log.info("---> Using class naming strategy: ${config.classNamingStrategy}")
-            log.info("---> Generate DSL: ${config.generateDsl}")
-            log.info("---> Generate Suspend DSL: ${config.generateSuspendDsl}")
-            log.info("---> Generate Enums: ${config.generateEnums}")
-            log.info("---> Generate Interfaces: ${config.generateInterfaces}")
-            log.info("---> Submodel only: ${config.submodelOnly}")
-            log.info("---> Feature name: ${config.featureName ?: "<derived from model title>"}")
+            log.debug("---> Using enum generation strategy: ${config.enumGenerationStrategy}")
+            log.debug("---> Using class naming strategy: ${config.classNamingStrategy}")
+            log.debug("---> Generate DSL: ${config.generateDsl}")
+            log.debug("---> Generate Suspend DSL: ${config.generateSuspendDsl}")
+            log.debug("---> Generate Enums: ${config.generateEnums}")
+            log.debug("---> Generate Interfaces: ${config.generateInterfaces}")
+            log.debug("---> Submodel only: ${config.submodelOnly}")
+            log.debug("---> Feature name: ${config.featureName ?: "<derived from model title>"}")
+            log.debug("---> Deduplicate referenced types: ${config.deduplicateReferencedTypes}")
 
             runBlocking {
                 GeneratorStarter.run(config)
             }
-            log.info("---> Adding path to compile source root: ${output.path}")
+            log.debug("---> Adding path to compile source root: ${output.path}")
             project!!.addCompileSourceRoot(output.path)
 
-            // Add common model directory to compile source roots
-            val commonModelDir = File(output.parent, "common-model")
-            if (commonModelDir.exists()) {
-                log.info("---> Adding common model path to compile source root: ${commonModelDir.path}")
-                project!!.addCompileSourceRoot(commonModelDir.path)
-            }
         } catch (e: Exception) {
             throw MojoExecutionException("Exception during generation", e)
         }
@@ -216,7 +217,8 @@ class WotKotlinCodegenMojo: AbstractMojo() {
             generateEnums = generateEnums,
             generateInterfaces = generateInterfaces,
             submodelOnly = submodelOnly,
-            featureName = featureName
+            featureName = featureName,
+            deduplicateReferencedTypes = deduplicateReferencedTypes
         )
     }
 }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
@@ -23,6 +23,7 @@ import org.eclipse.ditto.wot.kotlin.generator.plugin.dsl.DslGenerator
 import org.eclipse.ditto.wot.kotlin.generator.plugin.link.LinkRelationType
 import org.eclipse.ditto.wot.kotlin.generator.plugin.property.PropertyResolver
 import org.eclipse.ditto.wot.kotlin.generator.plugin.property.PropertyRole
+import org.eclipse.ditto.wot.kotlin.generator.plugin.property.TmRefScanner
 import org.eclipse.ditto.wot.kotlin.generator.plugin.property.ReferencePropertyResolver
 import org.eclipse.ditto.wot.kotlin.generator.plugin.property.SchemaTypeResolver
 import org.eclipse.ditto.wot.kotlin.generator.plugin.strategy.EnumGenerationStrategyFactory
@@ -95,7 +96,7 @@ object ClassGenerator {
     fun setEnumGenerationStrategy(config: GeneratorConfiguration) {
         val strategy = EnumGenerationStrategyFactory.createStrategy(config)
         enumGenerationStrategy = strategy
-        logger.info("Set enum generation strategy: ${config.enumGenerationStrategy}")
+        logger.debug("Set enum generation strategy: ${config.enumGenerationStrategy}")
 
         this.config = config
         dslGenerator.setConfiguration(config)
@@ -219,7 +220,7 @@ object ClassGenerator {
         originalName: String? = null,
         defaultConstants: List<PropertySpec> = emptyList()
     ) {
-        logger.debug("Generating class $className in package $packageName ...")
+        logger.debug("Generating class $className in package $packageName")
         val isPropertiesClass = typeSpec.superinterfaces.keys.any {
             (it as? ParameterizedTypeName)?.rawType == ClassName(Const.COMMON_PACKAGE_FEATURES, "Properties")
         }
@@ -354,10 +355,10 @@ object ClassGenerator {
             .addImport(Const.COMMON_PACKAGE_PATH, "HasPath")
 
         val superclass = typeSpecBuilder.build().superclass
-        logger.info("Class $className - superclass: $superclass")
+        logger.debug("Class $className - superclass: $superclass")
         if (superclass is ParameterizedTypeName && superclass.rawType.simpleName == "MapObjectProperty") {
             fileSpecBuilder.addImport(Const.COMMON_PACKAGE_FEATURES, "MapObjectProperty")
-            logger.info("Class $className - added MapObjectProperty import")
+            logger.debug("Class $className - added MapObjectProperty import")
         }
 
         funSpecs.forEach { fileSpecBuilder.addFunction(it) }
@@ -382,7 +383,7 @@ object ClassGenerator {
      * @param packageName The package for the type alias
      */
     fun generatePrimitiveTypeAlias(primitiveType: TypeName, className: String, packageName: String) {
-        logger.debug("Class $className will be typealias to primitive $primitiveType.")
+        logger.debug("Class $className will be typealias to primitive $primitiveType")
         val typeAliasSpec = TypeAliasSpec.builder(className, primitiveType).build()
         val file = FileSpec.builder(packageName, className).addTypeAlias(typeAliasSpec).build()
         file.writeTo(Path(outputDir))
@@ -419,7 +420,7 @@ object ClassGenerator {
      * @throws IllegalArgumentException if the enum already exists with different values or as a file from a previous generation
      */
     fun checkForEnumConflict(packageName: String, enumName: String, enumValues: Set<String>) {
-        val existingEnum = EnumRegistry.getEnumByName(enumName)
+        val existingEnum = EnumRegistry.getEnumByNameInPackage(enumName, packageName)
         if (existingEnum != null) {
             val existingValues = extractEnumValues(existingEnum)
             if (existingValues != enumValues) {
@@ -427,7 +428,7 @@ object ClassGenerator {
             }
             return
         }
-        
+
         val enumFilePath = Paths.get(outputDir, packageName.replace(".", "/"), "$enumName.kt")
         if (Files.exists(enumFilePath)) {
             throw IllegalArgumentException(
@@ -494,38 +495,113 @@ object ClassGenerator {
         asObjectProperty: Boolean = false,
         feature: String? = null,
         parentClassName: String? = null,
-        dittoCategory: String? = null
+        dittoCategory: String? = null,
+        tmRefUrl: String? = null
     ): TypeName {
-        val simpleClassName = if (config != null) {
-            asClassNameWithStrategy(name, parentClassName, config!!.classNamingStrategy, emptySet())
-        } else {
-            asClassName(name)
-        }
         val schemaJson = objectSchema.toJson()
+
+        val schemaFingerprint = if (config?.deduplicateReferencedTypes == true) {
+            TmRefScanner.computeFingerprint(objectSchema.toJson())
+        } else null
+
+        // When dedup is enabled and the schema comes from a tm:ref that is referenced by
+        // multiple properties, use the canonical title from the tm:ref target instead of the
+        // property name. This produces a more meaningful shared class name when multiple
+        // properties reference the same tm:ref type definition.
+        // Single-reference tm:refs keep the property name since there's no ambiguity.
+        // Falls back to the property name if:
+        // - The title produces the same class name as the property name (no benefit)
+        // - Another tm:ref already claimed this title globally (i.e., two distinct
+        //   tm:refs resolve to the same class name)
+        val effectiveName = if (config?.deduplicateReferencedTypes == true) {
+            val effectiveRefUrl = tmRefUrl
+                ?: schemaFingerprint?.let { SharedTypeRegistry.findRefUrlByFingerprint(it) }
+            if (effectiveRefUrl != null && SharedTypeRegistry.getRefCount(effectiveRefUrl) > 1) {
+                val refTitle = SharedTypeRegistry.findRefTitle(effectiveRefUrl)
+                if (refTitle != null) {
+                    val titleClassName = asClassName(refTitle)
+                    val nameClassName = asClassName(name)
+                    when {
+                        // No benefit if title produces the same class name
+                        titleClassName == nameClassName -> name
+                        // Title conflicts with another tm:ref's title (two distinct
+                        // tm:refs would produce the same class name)
+                        SharedTypeRegistry.hasConflictingTitle(effectiveRefUrl) -> name
+                        else -> refTitle
+                    }
+                } else name
+            } else {
+                name
+            }
+        } else {
+            name
+        }
+
+        val simpleClassName = if (config != null) {
+            asClassNameWithStrategy(effectiveName, parentClassName, config!!.classNamingStrategy, emptySet())
+        } else {
+            asClassName(effectiveName)
+        }
+
+        if (config?.deduplicateReferencedTypes == true) {
+            val effectiveRefUrl = tmRefUrl
+                ?: SharedTypeRegistry.findRefUrlByFingerprint(schemaFingerprint!!)
+
+            if (effectiveRefUrl != null) {
+                val existingByRef = SharedTypeRegistry.findClassByRef(effectiveRefUrl)
+                if (existingByRef != null) {
+                    logger.debug("Dedup: Reusing class {} for '{}' via tm:ref {}", existingByRef.canonicalName, name, effectiveRefUrl)
+                    return existingByRef.copy(nullable = true)
+                }
+            }
+            val resolvedForCheck = referencePropertyResolver.resolveReferenceProperties(objectSchema)
+            val existing = SharedTypeRegistry.findExistingClass(resolvedForCheck.toJson())
+            if (existing != null) {
+                logger.debug("Dedup: Reusing class {} for '{}' (schema match)", existing.canonicalName, name)
+                return existing.copy(nullable = true)
+            }
+        }
 
         if (ClassRegistry.hasConflict(packageName, simpleClassName, schemaJson)) {
             val prefix = parentClassName?.let { asClassName(it) } ?: feature ?: "Shared"
             val conflictResolvedClassName = "${prefix}${asClassName(name)}"
-            logger.warn("Class name conflict for '${asClassName(name)}' in package '$packageName'. Using new name '$conflictResolvedClassName'")
-            val finalClassName = conflictResolvedClassName
-            val resolvedObjectSchema = referencePropertyResolver.resolveReferenceProperties(objectSchema)
-            logger.info("Generating class $finalClassName - asObjectProperty: $asObjectProperty - feature: $feature")
+            logger.debug("Class name conflict for '${asClassName(name)}' in package '$packageName'. Using compound name '$conflictResolvedClassName'")
+            val (resolvedObjectSchema, nestedRefMap) = referencePropertyResolver.resolveWithRefTracking(objectSchema)
+            logger.debug("Generating conflict-resolved class $conflictResolvedClassName")
             if (asObjectProperty && feature != null) {
                 generateFeaturePropertyWrapperClass(resolvedObjectSchema, name, packageName, feature, role, dittoCategory)
             } else {
-                generateClassFromObjectSchema(name, resolvedObjectSchema, packageName, role, parentClassName)
+                // Pass the conflict-resolved name directly with null parentClassName
+                // to prevent the inner method from re-applying its own conflict resolution
+                generateClassFromObjectSchema(conflictResolvedClassName, resolvedObjectSchema, packageName, role, null, nestedRefMap, pathName = name)
             }
-            return ClassName(packageName, finalClassName).copy(nullable = true)
+            val generatedClassName = ClassName(packageName, conflictResolvedClassName)
+            if (config?.deduplicateReferencedTypes == true) {
+                SharedTypeRegistry.registerClass(resolvedObjectSchema.toJson(), generatedClassName)
+                if (tmRefUrl != null) {
+                    SharedTypeRegistry.registerClassByRef(tmRefUrl, generatedClassName)
+                }
+            }
+            return generatedClassName.copy(nullable = true)
         }
 
-        val resolvedObjectSchema = referencePropertyResolver.resolveReferenceProperties(objectSchema)
-        logger.info("Generating class $simpleClassName - asObjectProperty: $asObjectProperty - feature: $feature")
+        val (resolvedObjectSchema, nestedRefMap) = referencePropertyResolver.resolveWithRefTracking(objectSchema)
+        logger.info("Generating class $simpleClassName")
         if (asObjectProperty && feature != null) {
             generateFeaturePropertyWrapperClass(resolvedObjectSchema, name, packageName, feature, role, dittoCategory)
         } else {
-            generateClassFromObjectSchema(name, resolvedObjectSchema, packageName, role, parentClassName)
+            generateClassFromObjectSchema(effectiveName, resolvedObjectSchema, packageName, role, parentClassName, nestedRefMap, pathName = name)
         }
-        return ClassName(packageName, simpleClassName).copy(nullable = true)
+        val generatedClassName = ClassName(packageName, simpleClassName)
+        if (config?.deduplicateReferencedTypes == true) {
+            SharedTypeRegistry.registerClass(resolvedObjectSchema.toJson(), generatedClassName)
+            val effectiveRefUrl = tmRefUrl
+                ?: schemaFingerprint?.let { SharedTypeRegistry.findRefUrlByFingerprint(it) }
+            if (effectiveRefUrl != null) {
+                SharedTypeRegistry.registerClassByRef(effectiveRefUrl, generatedClassName)
+            }
+        }
+        return generatedClassName.copy(nullable = true)
     }
 
     /**
@@ -597,7 +673,9 @@ object ClassGenerator {
         objectSchema: ObjectSchema,
         packageName: String,
         role: PropertyRole,
-        parentClassName: String? = null
+        parentClassName: String? = null,
+        tmRefMap: Map<JsonPointer, String>? = null,
+        pathName: String? = null
     ) {
         var className = if (config != null) {
             asClassNameWithStrategy(propertyName, parentClassName, config!!.classNamingStrategy, emptySet())
@@ -619,12 +697,12 @@ object ClassGenerator {
             } else {
                 className = "Shared${asClassName(propertyName)}"
             }
-            logger.warn("Class name conflict for '${asClassName(propertyName)}' in package '$packageName'. Using new name '$className'")
+            logger.debug("Class name conflict for '${asClassName(propertyName)}' in package '$packageName'. Using compound name '$className'")
         }
         ClassRegistry.registerGeneratedClass(packageName, className, schemaToUse)
 
         val isMapLike = targetObjectSchema.isPatternPropertiesSchema() || targetObjectSchema.isAdditionalPropertiesSchema()
-        logger.info("Class $className - isMapLike: $isMapLike, schema: ${targetObjectSchema.toJson()}")
+        if (isMapLike) logger.debug("Class $className is map-like (patternProperties or additionalProperties)")
         val superClass = if (isMapLike) {
             val singleItemName = "${propertyName}Item"
             val singleItemNameAsClass = asClassName(singleItemName)
@@ -682,14 +760,14 @@ object ClassGenerator {
             for (entry in propertiesJson) {
                 val key = entry.key.toString()
                 val value = entry.value
-                logger.info("Property for $className: $key -> $value")
                 schemaMap[key] = SingleDataSchema.fromJson(value.asObject())
             }
             propertyResolver.convertFieldsToPropertySpecs(
                 schemaMap,
                 packageName,
                 role,
-                className
+                className,
+                tmRefMap
             )
         } else {
             emptyList()
@@ -728,7 +806,7 @@ object ClassGenerator {
                     extractDeprecationNotice(targetObjectSchema)
                 )
             ),
-            originalName = propertyName,
+            originalName = pathName ?: propertyName,
             defaultConstants = defaultValueExtractor.extractDefaultConstants(
                 schemaMap, packageName, updatedFields.associate { it.first to it.second.type }
             )
@@ -742,17 +820,14 @@ object ClassGenerator {
         val fields = propertyResolver.convertFieldsToPropertySpecs(objectSchema.properties, packageName, role, propertyName)
             .toMutableList()
         if (objectSchema.isPatternPropertiesSchema()) {
-            logger.debug("Found object schema with patternProperties: ${objectSchema.toJson()}")
             generatePatternPropertiesClass(propertyName, objectSchema, packageName, role)
         }
 
         if (objectSchema.isAdditionalPropertiesSchema()) {
-            logger.debug("Found object schema with additionalProperties: ${objectSchema.toJson()}")
             generateAdditionalPropertiesClass(propertyName, objectSchema, packageName, role)
         }
 
         if (objectSchemaJson.getValue(JsonPointer.of("oneOf")).isEmpty.not()) {
-            logger.debug("Found object schema with oneOf properties: ${objectSchema.toJson()}")
             fields += propertyResolver.resolveOneOfProperties(objectSchema, packageName, role)
         }
 
@@ -764,25 +839,11 @@ object ClassGenerator {
         typeSpecBuilder: TypeSpec.Builder,
         packageName: String
     ): List<Pair<String, PropertySpec>> {
-        logger.info("addInlineEnumsToTypeSpec called with enumGenerationStrategy: ${enumGenerationStrategy?.javaClass?.simpleName ?: "null"}")
-
-        val shouldAddInline = when {
-            enumGenerationStrategy != null -> {
-                when (enumGenerationStrategy!!::class.simpleName) {
-                    "InlineEnumGenerationStrategy" -> true
-                    "SeparateClassEnumGenerationStrategy" -> false
-                    else -> true // Default to inline for backward compatibility
-                }
-            }
-            else -> true // Default to inline for backward compatibility
-        }
+        val shouldAddInline = enumGenerationStrategy?.isInline != false
 
         if (!shouldAddInline) {
-            logger.info("Using separate class enum strategy - not adding enums inline")
             return fields
         }
-
-        logger.info("Using inline enum strategy - adding enums to class")
         val addedEnumNames = mutableSetOf<String>()
 
         val updatedFields = fields.map { field ->
@@ -793,7 +854,7 @@ object ClassGenerator {
                 parameterizedTypeName.typeArguments.forEach { typeArg ->
                     val className = typeArg as? ClassName
                     if (className != null) {
-                        val enumSpec = EnumRegistry.getEnumByName(className.simpleName)
+                        val enumSpec = EnumRegistry.getInlineEnumByName(className.simpleName)
                         if (enumSpec != null && addedEnumNames.add(enumSpec.name!!)) {
                             val hasExistingType = ClassRegistry.hasClass(packageName, className.simpleName) ||
                                                 typeSpecBuilder.build().typeSpecs.any { it.name == className.simpleName }
@@ -821,7 +882,7 @@ object ClassGenerator {
 
             val typeClass = currentField.type as? ClassName
             if (typeClass != null) {
-                val enumSpec = EnumRegistry.getEnumByName(typeClass.simpleName)
+                val enumSpec = EnumRegistry.getInlineEnumByName(typeClass.simpleName)
                 if (enumSpec != null && addedEnumNames.add(enumSpec.name!!)) {
                     val hasExistingType = ClassRegistry.hasClass(packageName, typeClass.simpleName) ||
                                         typeSpecBuilder.build().typeSpecs.any { it.name == typeClass.simpleName }
@@ -837,10 +898,6 @@ object ClassGenerator {
             }
 
             field.first to currentField
-        }
-
-        if (updatedFields != fields) {
-            logger.info("Updated fields with inline enums: ${updatedFields.size} fields")
         }
 
         return updatedFields
@@ -872,7 +929,7 @@ object ClassGenerator {
         objectSchema.toJson()
             .getValue(JsonPointer.of("additionalProperties"))
             .getOrNull()?.takeIf { it.isObject }?.asObject()?.let { additionalProperties ->
-                val title = objectSchema.title.get().toString()
+                val title = objectSchema.title.getOrNull()?.toString() ?: propertyName
 
                 val propertyNameSingular = "${propertyName ?: title}Item"
                 generateClassFromObjectSchema(
@@ -894,17 +951,13 @@ object ClassGenerator {
     ): TypeName {
         val propertyItemName = "${propertyName ?: title}Item"
         val patternPropertyClassName = asClassName(propertyItemName)
-        logger.info("[GEN] generateClassFromPatternProperties: propertyItemName=$propertyItemName, packageName=$packageName")
-        logger.debug("patternProperties: $patternProperties")
         patternProperties.keys.firstOrNull()?.let {
             val patternProperty = patternProperties.getField(it).getOrNull()
             if (patternProperty?.value is JsonObject) {
                 val patternPropertyObject = referencePropertyResolver.resolveReferenceProperties(
                     ObjectSchema.fromJson(patternProperty.value as JsonObject)
                 )
-                logger.info("[GEN] Calling generateClassFromObjectSchema for $propertyItemName in $packageName")
                 generateClassFromObjectSchema(propertyItemName, patternPropertyObject, packageName, role, propertyName)
-                logger.info("[GEN] Finished generateClassFromObjectSchema for $propertyItemName in $packageName")
                 return ClassName(packageName, patternPropertyClassName)
             } else {
                 throw IllegalArgumentException("Pattern property is not Object: $patternProperties")
@@ -1220,7 +1273,7 @@ object ClassGenerator {
         packageName: String,
         typeSpecBuilder: TypeSpec.Builder
     ): TypeName {
-        val itemSchema = arraySchema.items.getOrNull()!! as SingleDataSchema
+        val itemSchema = arraySchema.items.get() as SingleDataSchema
         val itemEnumArray = itemSchema.enum
         val itemHasEnum = itemEnumArray?.isNotEmpty() == true
 
@@ -1268,7 +1321,7 @@ object ClassGenerator {
             val enumKey = enumGenerationStrategy!!.generateEnum(
                 schema, propertyName, enumArray, schemaType, packageName, parentClassName
             )
-            val isInlineStrategy = enumGenerationStrategy!!.javaClass.simpleName == "InlineEnumGenerationStrategy"
+            val isInlineStrategy = enumGenerationStrategy!!.isInline
             if (isInlineStrategy) {
                 val enumSpec = EnumRegistry.getEnum(enumKey)
                 if (enumSpec != null) {
@@ -1276,7 +1329,16 @@ object ClassGenerator {
                 }
                 ClassName("", enumKey)
             } else {
-                ClassName(packageName, enumKey)
+                // For SEPARATE_CLASS with dedup, the enum may have been generated in a
+                // different package. Look it up in SharedTypeRegistry to get the correct ClassName.
+                val config = getConfig()
+                if (config?.deduplicateReferencedTypes == true) {
+                    SharedTypeRegistry.findExistingEnumByNameInPackage(enumKey, packageName)
+                        ?: SharedTypeRegistry.findExistingEnumByName(enumKey)
+                        ?: ClassName(packageName, enumKey)
+                } else {
+                    ClassName(packageName, enumKey)
+                }
             }
         } else {
             val enumKey = enumGenerator.generateEnum(

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassRegistry.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassRegistry.kt
@@ -20,10 +20,8 @@ object ClassRegistry {
     private fun getFullyQualifiedClassName(packageName: String, simpleClassName: String) = "$packageName.$simpleClassName"
 
     /**
-     * Checks if a class with the given name exists in the package but has a *different* structure.
-     */
-    /**
-     * Checks if there is a naming conflict for a class.
+     * Checks if there is a naming conflict for a class: a class with the given name
+     * already exists in the package but has a different structure.
      *
      * @param packageName The package name
      * @param simpleClassName The simple class name
@@ -49,10 +47,15 @@ object ClassRegistry {
     }
 
     /**
-     * Registers a newly generated class using its fully qualified name.
+     * Clears all registered classes. Called at the start of each generation run
+     * to prevent stale entries from a previous model leaking into the current one.
      */
+    fun clear() {
+        registry.clear()
+    }
+
     /**
-     * Registers a generated class.
+     * Registers a generated class using its fully qualified name.
      *
      * @param packageName The package name
      * @param simpleClassName The simple class name

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/EnumRegistry.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/EnumRegistry.kt
@@ -26,13 +26,24 @@ import java.util.*
  */
 object EnumRegistry {
     private val enums = mutableMapOf<String, TypeSpec>()
-    private val nameToKey = mutableMapOf<String, String>()
+    /** Maps (packageName, enumName) → key for package-aware lookups. */
+    private val packageNameToKey = mutableMapOf<Pair<String, String>, String>()
+    /** Maps enumName → key for inline enums (no package). */
+    private val inlineNameToKey = mutableMapOf<String, String>()
     /**
      * Tracks enum values by package and name to detect conflicts.
      * Key: Pair(packageName, enumName)
      * Value: Set of enum constant names
      */
     private val enumValuesByPackageAndName = mutableMapOf<Pair<String, String>, Set<String>>()
+
+    /** Clears all registry state. Primarily intended for tests. */
+    fun clear() {
+        enums.clear()
+        packageNameToKey.clear()
+        inlineNameToKey.clear()
+        enumValuesByPackageAndName.clear()
+    }
 
     /**
      * Registers an enum type specification for inline enums (without UUID suffix).
@@ -43,7 +54,7 @@ object EnumRegistry {
     fun registerEnumInline(typeSpec: TypeSpec): String {
         val name = typeSpec.name!!
         enums[name] = typeSpec
-        nameToKey[name] = name
+        inlineNameToKey[name] = name
         return name
     }
 
@@ -65,47 +76,84 @@ object EnumRegistry {
         val enumName = typeSpec.name!!
         val packageAndName = Pair(packageName, enumName)
         val existingValues = enumValuesByPackageAndName[packageAndName]
-        
+
         if (existingValues != null) {
             if (existingValues != enumValues) {
                 throw EnumConflictUtils.createEnumConflictException(enumName, packageName, existingValues, enumValues)
             }
-            val existingKey = nameToKey[enumName]
+            val existingKey = packageNameToKey[packageAndName]
             return existingKey ?: generateUniqueKey(enumName).also {
                 enums[it] = typeSpec
-                nameToKey[enumName] = it
+                packageNameToKey[packageAndName] = it
             }
         }
-        
+
         val newKey = generateUniqueKey(enumName)
         enums[newKey] = typeSpec
-        nameToKey[enumName] = newKey
+        packageNameToKey[packageAndName] = newKey
         enumValuesByPackageAndName[packageAndName] = enumValues
         return newKey
     }
-    
+
     /**
      * Registers an enum type specification (backward compatibility - without value checking).
-     * 
+     *
      * @param typeSpec The type specification for the enum
      * @return The key for the registered enum
      */
     fun registerEnum(typeSpec: TypeSpec): String {
         val key = generateUniqueKey(typeSpec.name!!)
         enums[key] = typeSpec
-        nameToKey[typeSpec.name!!] = key
         return key
     }
 
     /**
-     * Gets an enum by its name.
+     * Gets an enum by its name from any package.
+     * Checks inline enums first, then package-scoped enums.
      *
      * @param name The name of the enum
      * @return The enum type specification or null if not found
      */
     fun getEnumByName(name: String): TypeSpec? {
-        val key = nameToKey[name]
-        return key?.let { enums[it] }
+        val inlineKey = inlineNameToKey[name]
+        if (inlineKey != null) return enums[inlineKey]
+        val packageKey = packageNameToKey.entries.firstOrNull { it.key.second == name }?.value
+        return packageKey?.let { enums[it] }
+    }
+
+    /**
+     * Gets an inline enum by its simple name.
+     */
+    fun getInlineEnumByName(name: String): TypeSpec? {
+        return inlineNameToKey[name]?.let { enums[it] }
+    }
+
+    /**
+     * Gets a package-scoped enum by exact package and name.
+     */
+    fun getEnumByNameInPackage(name: String, packageName: String): TypeSpec? {
+        return packageNameToKey[packageName to name]?.let { enums[it] }
+    }
+
+    /**
+     * Gets the package name where an enum was first registered.
+     */
+    fun getEnumPackage(name: String): String? {
+        return enumValuesByPackageAndName.keys.firstOrNull { it.second == name }?.first
+    }
+
+    /**
+     * Gets the stored enum constant values for an enum in an exact package.
+     */
+    fun getEnumValuesInPackage(packageName: String, name: String): Set<String>? {
+        return enumValuesByPackageAndName[packageName to name]
+    }
+
+    /**
+     * Gets the stored enum constant values for a given enum name (from any package).
+     */
+    fun getEnumValues(name: String): Set<String>? {
+        return enumValuesByPackageAndName.entries.firstOrNull { it.key.second == name }?.value
     }
 
     /**
@@ -123,8 +171,8 @@ object EnumRegistry {
      *
      * @return A map of enum keys to their type specifications
      */
-    fun getEnums(): MutableMap<String, TypeSpec> {
-        return enums
+    fun getEnums(): Map<String, TypeSpec> {
+        return enums.toMap()
     }
 
     private fun generateUniqueKey(baseName: String): String {

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/SharedTypeRegistry.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/SharedTypeRegistry.kt
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.clazz
+
+import com.squareup.kotlinpoet.ClassName
+import org.eclipse.ditto.json.JsonFactory
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.json.JsonValue
+import org.eclipse.ditto.wot.kotlin.generator.plugin.util.asClassName
+import org.eclipse.ditto.wot.model.DataSchemaType
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Registry for deduplicating types across packages.
+ *
+ * When [org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration.deduplicateReferencedTypes]
+ * is enabled, this registry tracks generated classes and enums by:
+ * 1. **tm:ref URL** (primary) — types from the same `tm:ref` are generated once; the first encounter
+ *    determines the name and package, subsequent encounters reuse it.
+ * 2. **Schema JSON content** (fallback) — for types without `tm:ref`, structurally identical schemas
+ *    are deduplicated.
+ *
+ * ## Lifecycle
+ *
+ * The registry has two clearing stages by design:
+ * - [clearRefMappings] — called by `TmRefScanner.scan()` before the pre-scan. Clears only the
+ *   `schemaToRefUrl` fingerprint map, then repopulates it from the raw model JSON.
+ * - [clear] — called by `ThingModelGenerator.generate()` before class generation. Clears all
+ *   generation-time registries (`classRegistry`, `enumRegistry`, ref registries) but preserves
+ *   `schemaToRefUrl` so the generator can look up fingerprints during generation.
+ *
+ * This two-stage design is intentional: the pre-scan runs first and populates `schemaToRefUrl`,
+ * then `clear()` resets generation state without losing the pre-scanned fingerprint mappings.
+ *
+ * **Thread safety:** All internal registries use [ConcurrentHashMap]. The generator still runs
+ * in a mostly single-threaded Maven execution model today, but these maps are safe for concurrent
+ * access if the generator is invoked programmatically.
+ */
+object SharedTypeRegistry {
+
+    /** Maps normalized schema JSON → ClassName where the class was first generated. */
+    private val classRegistry = ConcurrentHashMap<String, ClassName>()
+
+    /** Maps enum structural key → ClassName where the enum was first generated. */
+    private val enumRegistry = ConcurrentHashMap<String, ClassName>()
+
+    /** Maps enum schema JSON → ClassName for schema-based dedup (tm:ref). */
+    private val enumSchemaRegistry = ConcurrentHashMap<String, ClassName>()
+
+    /** Maps tm:ref URL → ClassName for classes generated from that ref. */
+    private val classRefRegistry = ConcurrentHashMap<String, ClassName>()
+
+    /** Maps tm:ref URL → ClassName for enums generated from that ref (SEPARATE_CLASS only). */
+    private val enumRefRegistry = ConcurrentHashMap<String, ClassName>()
+
+    /** Maps resolved schema content → tm:ref URL (populated by TmRefScanner pre-scan). */
+    private val schemaToRefUrl = ConcurrentHashMap<String, String>()
+
+    /** Maps tm:ref URL → canonical title from the referenced schema (populated by TmRefScanner pre-scan). */
+    private val refTitleRegistry = ConcurrentHashMap<String, String>()
+
+    /** Maps tm:ref URL → number of properties referencing it (populated by TmRefScanner pre-scan). */
+    private val refCountRegistry = ConcurrentHashMap<String, Int>()
+
+    /** Maps (packageName, enumName) → ClassName for exact package resolution of deduplicated enums. */
+    private val enumPackageRegistry = ConcurrentHashMap<Pair<String, String>, ClassName>()
+
+    /** Set of tm:ref URLs whose titles conflict with another tm:ref's title.
+     *  These refs should NOT use the title for naming. Populated by [markConflictingTitles]. */
+    private val conflictingTitleRefs = ConcurrentHashMap.newKeySet<String>()
+
+    /**
+     * Clears all registered types. Called at the start of each generation run.
+     * Does NOT clear [schemaToRefUrl] — that is managed by [TmRefScanner.scan] which
+     * calls [clearRefMappings] at the start of each scan.
+     */
+    fun clear() {
+        classRegistry.clear()
+        enumRegistry.clear()
+        enumSchemaRegistry.clear()
+        classRefRegistry.clear()
+        enumRefRegistry.clear()
+        enumPackageRegistry.clear()
+    }
+
+    /**
+     * Clears the fingerprint → tm:ref URL mappings. Called by [TmRefScanner.scan] at the
+     * start of each scan to prevent stale mappings from a previous model leaking into the
+     * current one in multi-execution builds.
+     */
+    fun clearRefMappings() {
+        schemaToRefUrl.clear()
+        refTitleRegistry.clear()
+        refCountRegistry.clear()
+        conflictingTitleRefs.clear()
+    }
+
+    /**
+     * Finds an existing class generated from a structurally identical schema.
+     *
+     * @param schemaJson The schema JSON of the class to check
+     * @return The [ClassName] of the existing class, or null if no match
+     */
+    fun findExistingClass(schemaJson: JsonObject): ClassName? {
+        return classRegistry[normalizeSchema(schemaJson)]
+    }
+
+    /**
+     * Registers a newly generated class by its schema structure.
+     *
+     * @param schemaJson The schema JSON of the generated class
+     * @param className The [ClassName] where it was generated
+     */
+    fun registerClass(schemaJson: JsonObject, className: ClassName) {
+        classRegistry[normalizeSchema(schemaJson)] = className
+    }
+
+    /**
+     * Finds an existing enum generated with identical values and schema type.
+     *
+     * @param enumValues The set of enum constant names
+     * @param schemaType The WoT schema type (STRING, INTEGER, etc.)
+     * @return The [ClassName] of the existing enum, or null if no match
+     */
+    fun findExistingEnum(enumValues: Set<String>, schemaType: DataSchemaType): ClassName? {
+        return enumRegistry[buildEnumKey(enumValues, schemaType)]
+    }
+
+    /**
+     * Registers a newly generated enum by its values and schema type.
+     *
+     * @param enumValues The set of enum constant names
+     * @param schemaType The WoT schema type
+     * @param className The [ClassName] where it was generated
+     */
+    fun registerEnum(enumValues: Set<String>, schemaType: DataSchemaType, className: ClassName) {
+        enumRegistry[buildEnumKey(enumValues, schemaType)] = className
+        enumPackageRegistry[className.packageName to className.simpleName] = className
+    }
+
+    /**
+     * Finds an existing enum by its simple name (regardless of schema type or values).
+     * Used by [org.eclipse.ditto.wot.kotlin.generator.plugin.property.WrapperTypeChecker]
+     * to resolve the canonical package for a deduplicated enum.
+     *
+     * @param enumName The simple name of the enum
+     * @return The [ClassName] if found, or null
+     */
+    fun findExistingEnumByName(enumName: String): ClassName? {
+        return enumRegistry.values.firstOrNull { it.simpleName == enumName }
+    }
+
+    /**
+     * Finds an existing enum by exact package and simple name.
+     */
+    fun findExistingEnumByNameInPackage(enumName: String, packageName: String): ClassName? {
+        return enumPackageRegistry[packageName to enumName]
+    }
+
+    /**
+     * Registers an alias so that looking up [enumName] in [requestingPackage] returns
+     * [canonicalClassName] (which lives in a different package). This enables cross-package
+     * dedup for SEPARATE_CLASS enums: the enum is generated once in the first package,
+     * and subsequent packages get a reference pointing to the original.
+     */
+    fun registerEnumAlias(requestingPackage: String, enumName: String, canonicalClassName: ClassName) {
+        enumPackageRegistry[requestingPackage to enumName] = canonicalClassName
+    }
+
+    /**
+     * Finds an existing enum generated from the same schema JSON (tm:ref dedup).
+     */
+    fun findExistingEnumBySchema(schemaKey: String): ClassName? {
+        return enumSchemaRegistry[schemaKey]
+    }
+
+    /**
+     * Registers an enum by its schema JSON for tm:ref based dedup.
+     */
+    fun registerEnumBySchema(schemaKey: String, className: ClassName) {
+        enumSchemaRegistry[schemaKey] = className
+    }
+
+    // --- tm:ref URL-based dedup ---
+
+    /** Finds a class previously generated from the given [refUrl]. */
+    fun findClassByRef(refUrl: String): ClassName? = classRefRegistry[refUrl]
+
+    /** Registers a generated class against its source [refUrl] for future dedup lookups. */
+    fun registerClassByRef(refUrl: String, className: ClassName) {
+        classRefRegistry[refUrl] = className
+    }
+
+    /** Finds an enum previously generated from the given [refUrl] (SEPARATE_CLASS strategy only). */
+    fun findEnumByRef(refUrl: String): ClassName? = enumRefRegistry[refUrl]
+
+    /** Registers a generated enum against its source [refUrl] for future dedup lookups. */
+    fun registerEnumByRef(refUrl: String, className: ClassName) {
+        enumRefRegistry[refUrl] = className
+        enumPackageRegistry[className.packageName to className.simpleName] = className
+    }
+
+    /**
+     * Registers a mapping from a structural fingerprint to its source `tm:ref` URL.
+     * Called by [TmRefScanner] during the pre-scan phase, before the WoT library resolves references.
+     */
+    fun registerRefMapping(fingerprint: String, refUrl: String) {
+        schemaToRefUrl[fingerprint] = refUrl
+    }
+
+    /**
+     * Registers the canonical title from a `tm:ref` target schema.
+     * Called by [TmRefScanner] during the pre-scan phase. This title represents the
+     * type's semantic name as defined at the reference source, before local overrides
+     * (e.g., a shared schema referenced by multiple properties with context-specific names).
+     */
+    fun registerRefTitle(refUrl: String, title: String) {
+        refTitleRegistry[refUrl] = title
+    }
+
+    /**
+     * Finds the canonical title for a `tm:ref` URL, as defined in the referenced schema.
+     */
+    fun findRefTitle(refUrl: String): String? = refTitleRegistry[refUrl]
+
+    /**
+     * Increments the reference count for a `tm:ref` URL. Called by [TmRefScanner] each time
+     * a property referencing this URL is encountered during the pre-scan.
+     */
+    fun incrementRefCount(refUrl: String) {
+        refCountRegistry.merge(refUrl, 1, Int::plus)
+    }
+
+    /**
+     * Returns how many properties reference this `tm:ref` URL.
+     */
+    fun getRefCount(refUrl: String): Int = refCountRegistry.getOrDefault(refUrl, 0)
+
+    /**
+     * Returns true if the given tm:ref URL has a title that conflicts with another tm:ref's title.
+     * Must be called after [markConflictingTitles].
+     */
+    fun hasConflictingTitle(refUrl: String): Boolean = refUrl in conflictingTitleRefs
+
+    /**
+     * Analyzes all registered tm:ref titles and marks refs whose titles would produce the same
+     * class name as another ref's title. Called by [TmRefScanner.scan] after the pre-scan completes.
+     * E.g., two distinct tm:ref URLs whose target schemas share the same title
+     * would produce the same class name, causing a collision.
+     */
+    fun markConflictingTitles() {
+        // Group refs by the class name their title would produce (using the same
+        // asClassName() transform used for actual code generation)
+        val titleToRefs = refTitleRegistry.entries
+            .groupBy { (_, title) -> asClassName(title) }
+            .filter { (_, refs) -> refs.size > 1 }
+
+        for ((_, refs) in titleToRefs) {
+            for ((refUrl, _) in refs) {
+                conflictingTitleRefs.add(refUrl)
+            }
+        }
+    }
+
+    /**
+     * Finds the `tm:ref` URL for a resolved schema by matching its structural fingerprint
+     * against the pre-scanned registry. Returns null if no match (schema did not come from a `tm:ref`).
+     */
+    fun findRefUrlByFingerprint(fingerprint: String): String? {
+        return schemaToRefUrl[fingerprint]
+    }
+
+    /**
+     * Normalizes a schema JSON for class-level dedup comparison by sorting keys recursively.
+     * This ensures structurally identical schemas with different key insertion order produce
+     * the same string. Unlike [TmRefScanner.computeFingerprint], this preserves all fields
+     * (including title, description, etc.) since schemas with different titles may represent
+     * intentionally distinct types even if their structural shape is identical.
+     */
+    private fun normalizeSchema(schemaJson: JsonObject): String = sortKeysRecursive(schemaJson).toString()
+
+    private fun sortKeysRecursive(jsonObject: JsonObject): JsonObject {
+        val builder = JsonFactory.newObjectBuilder()
+        jsonObject.keys.map { it.toString() }.sorted().forEach { key ->
+            val field = jsonObject.getField(key).orElse(null) ?: return@forEach
+            val value = field.value
+            builder.set(key, sortValueRecursive(value))
+        }
+        return builder.build()
+    }
+
+    private fun sortValueRecursive(value: JsonValue): JsonValue {
+        return when {
+            value.isObject -> sortKeysRecursive(value.asObject())
+            value.isArray -> {
+                val arrayBuilder = JsonFactory.newArrayBuilder()
+                value.asArray().forEach { arrayBuilder.add(sortValueRecursive(it)) }
+                arrayBuilder.build()
+            }
+            else -> value
+        }
+    }
+
+    private fun buildEnumKey(enumValues: Set<String>, schemaType: DataSchemaType): String {
+        return "${schemaType.name}:${enumValues.sorted().joinToString(",")}"
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/ConfigurationBuilder.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/ConfigurationBuilder.kt
@@ -28,15 +28,18 @@ class ConfigurationBuilder {
     private var outputPackage: String? = null
     private var outputDirectory: File? = null
 
-    // Enum generation strategy
+    // Strategy parameters
     private var enumGenerationStrategy: EnumGenerationStrategy = EnumGenerationStrategy.INLINE
+    private var classNamingStrategy: ClassNamingStrategy = ClassNamingStrategy.COMPOUND_ALL
 
-    // Backward compatibility parameters
+    // Generation flags
     private var generateDsl: Boolean = true
+    private var generateSuspendDsl: Boolean = false
     private var generateEnums: Boolean = true
     private var generateInterfaces: Boolean = true
     private var submodelOnly: Boolean = false
     private var featureName: String? = null
+    private var deduplicateReferencedTypes: Boolean = false
 
     /**
      * Sets the URL or path to the WoT Thing Model to process.
@@ -75,6 +78,22 @@ class ConfigurationBuilder {
      */
     fun enumGenerationStrategy(strategy: EnumGenerationStrategy): ConfigurationBuilder {
         this.enumGenerationStrategy = strategy
+        return this
+    }
+
+    /**
+     * Sets the strategy for naming generated classes.
+     */
+    fun classNamingStrategy(strategy: ClassNamingStrategy): ConfigurationBuilder {
+        this.classNamingStrategy = strategy
+        return this
+    }
+
+    /**
+     * Sets whether DSL builder functions should be suspend functions.
+     */
+    fun generateSuspendDsl(generate: Boolean): ConfigurationBuilder {
+        this.generateSuspendDsl = generate
         return this
     }
 
@@ -135,6 +154,16 @@ class ConfigurationBuilder {
     }
 
     /**
+     * Enables deduplication of referenced types.
+     * When enabled, types from the same tm:ref are generated once.
+     * The first encounter determines the name and package; subsequent uses reuse it.
+     */
+    fun deduplicateReferencedTypes(enabled: Boolean): ConfigurationBuilder {
+        this.deduplicateReferencedTypes = enabled
+        return this
+    }
+
+    /**
      * Applies a minimal configuration suitable for simple code generation.
      */
     fun minimal(): ConfigurationBuilder {
@@ -182,11 +211,14 @@ class ConfigurationBuilder {
             outputPackage = outputPackage!!,
             outputDirectory = outputDirectory!!,
             enumGenerationStrategy = enumGenerationStrategy,
+            classNamingStrategy = classNamingStrategy,
             generateDsl = generateDsl,
+            generateSuspendDsl = generateSuspendDsl,
             generateEnums = generateEnums,
             generateInterfaces = generateInterfaces,
             submodelOnly = submodelOnly,
-            featureName = featureName
+            featureName = featureName,
+            deduplicateReferencedTypes = deduplicateReferencedTypes
         )
     }
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/GeneratorConfiguration.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/GeneratorConfiguration.kt
@@ -61,7 +61,15 @@ data class GeneratorConfiguration(
      * If not set, the name is derived from the model title in camelCase.
      * Only used when [submodelOnly] is true.
      */
-    val featureName: String? = null
+    val featureName: String? = null,
+
+    /**
+     * When true, types referenced from the same `tm:ref` URL are generated only once.
+     * The first encounter determines the name and package; subsequent encounters reuse
+     * that class instead of generating a duplicate. For types without `tm:ref`, structurally
+     * identical schemas with the same class name are also deduplicated.
+     */
+    val deduplicateReferencedTypes: Boolean = false
 ) {
     /**
      * Creates a copy with updated values, useful for building configurations incrementally.
@@ -77,7 +85,8 @@ data class GeneratorConfiguration(
         generateEnums: Boolean? = null,
         generateInterfaces: Boolean? = null,
         submodelOnly: Boolean? = null,
-        featureName: String? = null
+        featureName: String? = null,
+        deduplicateReferencedTypes: Boolean? = null
     ): GeneratorConfiguration {
         return copy(
             thingModelUrl = thingModelUrl ?: this.thingModelUrl,
@@ -90,7 +99,8 @@ data class GeneratorConfiguration(
             generateEnums = generateEnums ?: this.generateEnums,
             generateInterfaces = generateInterfaces ?: this.generateInterfaces,
             submodelOnly = submodelOnly ?: this.submodelOnly,
-            featureName = featureName ?: this.featureName
+            featureName = featureName ?: this.featureName,
+            deduplicateReferencedTypes = deduplicateReferencedTypes ?: this.deduplicateReferencedTypes
         )
     }
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/dsl/DslGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/dsl/DslGenerator.kt
@@ -162,12 +162,12 @@ object DslGenerator {
             } else {
                 val itemName = "${prop.title.getOrNull()?.let { title -> asPropertyName(title.toString()) } ?:  property}Item"
                 // Use the actual class name from the itemType instead of generating it
-                val itemAsClass = when (itemType) {
-                    is ClassName -> itemType.simpleName
-                    is ParameterizedTypeName -> (itemType.rawType as? ClassName)?.simpleName ?: asClassName(itemName)
-                    else -> asClassName(itemName)
+                val itemsPropertyClass = when (itemType) {
+                    is ClassName -> itemType
+                    is ParameterizedTypeName -> (itemType.rawType as? ClassName) ?: ClassName(propertyPackage, asClassName(itemName))
+                    else -> ClassName(propertyPackage, asClassName(itemName))
                 }
-                val itemsPropertyClass = ClassName(propertyPackage, itemAsClass)
+                val itemAsClass = itemsPropertyClass.simpleName
                 val funSpecBuilder = FunSpec.builder(itemName)
                     .returns(itemsPropertyClass)
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/PropertyResolver.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/PropertyResolver.kt
@@ -16,6 +16,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.UNIT
+import org.eclipse.ditto.json.JsonKey
 import org.eclipse.ditto.json.JsonObject
 import org.eclipse.ditto.json.JsonPointer
 import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.ClassGenerator
@@ -26,6 +27,7 @@ import kotlin.jvm.optionals.getOrNull
 
 object PropertyResolver {
 
+    private val rootPropertiesPath = JsonPointer.of("properties")
     private val classGenerator = ClassGenerator
     private val wrapperTypeChecker = WrapperTypeChecker
     private val schemaTypeResolver = SchemaTypeResolver
@@ -43,11 +45,16 @@ object PropertyResolver {
         properties: Properties?,
         parentPackage: String,
         role: PropertyRole,
-        feature: String? = null
+        feature: String? = null,
+        tmRefMap: Map<JsonPointer, String>? = null
     ): MutableMap<Pair<Property, PropertySpec>, String?> {
         return properties?.filter { it.value.type.isPresent || it.value.toJson().contains("tm:ref") }?.map {
             val dittoCategory = extractPropertyCategory(it.value.toJson())
-            val type = resolvePropertyType(it.value, parentPackage, role, feature, dittoCategory)
+            val propertyTmRef = resolveTmRefForProperty(it.key, tmRefMap, it.value.toJson(), rootPropertiesPath)
+            if (propertyTmRef != null) {
+                logger.debug("Found tm:ref for property '{}': {}", it.key, propertyTmRef)
+            }
+            val type = resolvePropertyType(it.value, parentPackage, role, feature, dittoCategory, propertyTmRef)
             Pair(
                 it.value,
                 createPropertySpec(it.key, type)
@@ -68,10 +75,13 @@ object PropertyResolver {
         fields: Map<String, SingleDataSchema>,
         packageName: String,
         role: PropertyRole,
-        parentClassName: String? = null
+        parentClassName: String? = null,
+        tmRefMap: Map<JsonPointer, String>? = null,
+        currentPropertiesPath: JsonPointer = rootPropertiesPath
     ): List<Pair<String, PropertySpec>> {
         return fields.map {
-            val poetType = schemaTypeResolver.resolveSchemaType(it.value, packageName, role, it.key, parentClassName)
+            val fieldTmRef = resolveTmRefForProperty(it.key, tmRefMap, it.value.toJson(), currentPropertiesPath)
+            val poetType = schemaTypeResolver.resolveSchemaType(it.value, packageName, role, it.key, parentClassName, fieldTmRef)
             it.key to createPropertySpec(it.key, poetType)
         }
     }
@@ -118,11 +128,33 @@ object PropertyResolver {
     }
 
 
+    /**
+     * Extracts a top-level tm:ref URL directly from a property's JSON.
+     * Returns null if the property has no tm:ref or the value is not a string.
+     */
+    private fun extractTmRef(propertyJson: JsonObject): String? {
+        val ref = propertyJson.getValue(JsonPointer.of("tm:ref")).getOrNull() ?: return null
+        return try {
+            ref.asString().replace("\"", "")
+        } catch (e: UnsupportedOperationException) {
+            logger.warn("tm:ref value is not a string in {}: {}", propertyJson, e.message)
+            null
+        }
+    }
+
+    private fun resolveTmRefForProperty(
+        propertyName: String,
+        tmRefMap: Map<JsonPointer, String>?,
+        propertyJson: JsonObject,
+        propertiesPath: JsonPointer
+    ): String? {
+        val propertyPath = propertiesPath.addLeaf(JsonKey.of(propertyName))
+        return tmRefMap?.get(propertyPath) ?: extractTmRef(propertyJson)
+    }
+
     private fun extractPropertyCategory(propertyJson: JsonObject): String? {
-        val propertyCategoryString = propertyJson.getValue(JsonPointer.of("ditto:category"))
+        return propertyJson.getValue(JsonPointer.of("ditto:category"))
             .getOrNull()?.asString()
-        logger.debug("Extracted property category: $propertyCategoryString")
-        return propertyCategoryString
     }
 
     private fun resolvePropertyType(
@@ -130,7 +162,8 @@ object PropertyResolver {
         propertyPackage: String,
         role: PropertyRole,
         feature: String?,
-        dittoCategory: String?
+        dittoCategory: String?,
+        tmRefUrl: String? = null
     ): TypeName {
         return when (property.type.get()) {
             DataSchemaType.BOOLEAN -> wrapperTypeChecker.checkForWrapperType(
@@ -141,7 +174,8 @@ object PropertyResolver {
                 role,
                 feature,
                 dittoCategory,
-                parentClassName = null
+                parentClassName = null,
+                tmRefUrl = tmRefUrl
             )
 
             DataSchemaType.INTEGER -> wrapperTypeChecker.checkForWrapperType(
@@ -152,7 +186,8 @@ object PropertyResolver {
                 role,
                 feature,
                 dittoCategory,
-                parentClassName = null
+                parentClassName = null,
+                tmRefUrl = tmRefUrl
             )
 
             DataSchemaType.NUMBER  -> wrapperTypeChecker.checkForWrapperType(
@@ -163,7 +198,8 @@ object PropertyResolver {
                 role,
                 feature,
                 dittoCategory,
-                parentClassName = null
+                parentClassName = null,
+                tmRefUrl = tmRefUrl
             )
 
             DataSchemaType.STRING  -> wrapperTypeChecker.checkForWrapperType(
@@ -174,7 +210,8 @@ object PropertyResolver {
                 role,
                 feature,
                 dittoCategory,
-                parentClassName = null
+                parentClassName = null,
+                tmRefUrl = tmRefUrl
             )
 
             DataSchemaType.OBJECT  -> {
@@ -187,7 +224,8 @@ object PropertyResolver {
                         role,
                         feature,
                         dittoCategory,
-                        parentClassName = null
+                        parentClassName = null,
+                        tmRefUrl = tmRefUrl
                     )
                 } else {
                     val objectSchema = property.asObjectSchema()
@@ -199,7 +237,8 @@ object PropertyResolver {
                         asObjectProperty = objectSchema.isPatternPropertiesSchema() || objectSchema.isAdditionalPropertiesSchema(),
                         feature = feature,
                         parentClassName = null,
-                        dittoCategory = dittoCategory
+                        dittoCategory = dittoCategory,
+                        tmRefUrl = tmRefUrl
                     )
                 }
             }
@@ -208,7 +247,8 @@ object PropertyResolver {
                 property.asArraySchema(),
                 propertyPackage,
                 role,
-                property.propertyName
+                property.propertyName,
+                tmRefUrl
             )
 
             DataSchemaType.NULL    -> UNIT.copy(nullable = true)
@@ -232,6 +272,4 @@ object PropertyResolver {
 
 
 }
-
-
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/ReferencePropertyResolver.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/ReferencePropertyResolver.kt
@@ -25,27 +25,63 @@ object ReferencePropertyResolver {
 
     private val logger = LoggerFactory.getLogger(ReferencePropertyResolver::class.java)
 
-    fun resolveReferenceProperties(objectSchema: ObjectSchema): ObjectSchema {
+    /**
+     * Collects all `tm:ref` entries from [jsonObject], returning a map of parent JSON path → ref URL.
+     *
+     * The returned key is the path of the object containing the `tm:ref`, not the `tm:ref` field itself.
+     */
+    fun collectReferenceFields(jsonObject: JsonObject): Map<JsonPointer, String> {
+        val foundReferences = mutableMapOf<JsonPointer, String>()
+        findReferenceFieldsRecursively(jsonObject, JsonPointer.empty(), foundReferences)
+        return foundReferences
+    }
+
+    /**
+     * Resolves all tm:ref references in the schema, inlining the referenced content.
+     * Also returns a map of JSON paths → tm:ref URLs for deduplication tracking.
+     */
+    fun resolveWithRefTracking(objectSchema: ObjectSchema): Pair<ObjectSchema, Map<JsonPointer, String>> {
         var jsonWithRefs = objectSchema.toJson()
-        val referenceFields: MutableMap<JsonPointer, String> = mutableMapOf()
-        findReferenceFieldsRecursively(objectSchema.toJson(), JsonPointer.empty(), referenceFields)
-        referenceFields.keys.forEach {
-            val referenceLink = referenceFields[it]
-            val hashCount = referenceLink?.count { it == '#' }
+        val referenceFields = collectReferenceFields(objectSchema.toJson())
+
+        val refMap = mutableMapOf<JsonPointer, String>()
+        referenceFields.forEach { (referencePath, referenceLink) ->
+            val hashCount = referenceLink?.count { ch -> ch == '#' }
             require(hashCount == 1) { "Unsupported reference link: $referenceLink" }
-            val linkParts = referenceLink!!.replace("\"", "").split("#", limit = 2)
+            val cleanUrl = referenceLink!!.replace("\"", "")
+            refMap[referencePath] = cleanUrl
+
+            val linkParts = cleanUrl.split("#", limit = 2)
             val linkUrl = linkParts[0]
             val linkPath = linkParts[1]
             val linkJson = loadJson(linkUrl)
             val replacementJson = readJsonValue(linkJson, JsonPointer.of(linkPath))
             if (replacementJson != null) {
-                jsonWithRefs = replaceJsonValue(jsonWithRefs, it, replacementJson)
-                logger.debug("Setting jsonWithRefs= $jsonWithRefs")
+                jsonWithRefs = replaceJsonValue(jsonWithRefs, referencePath, replacementJson)
+            } else {
+                logger.warn("Could not resolve tm:ref at path '{}' in '{}' — referenced content not found", linkPath, linkUrl)
             }
         }
-        return ObjectSchema.fromJson(jsonWithRefs)
+        return ObjectSchema.fromJson(jsonWithRefs) to refMap
     }
 
+    /**
+     * Resolves all tm:ref references, discarding the ref tracking info.
+     * Backward-compatible with existing callers.
+     */
+    fun resolveReferenceProperties(objectSchema: ObjectSchema): ObjectSchema {
+        return resolveWithRefTracking(objectSchema).first
+    }
+
+    /**
+     * Recursively walks a [JsonObject] collecting all `tm:ref` entries.
+     * Each found `tm:ref` is stored in [foundReferences] with the **parent** path as key
+     * (not the `tm:ref` field itself) and the reference URL as value.
+     *
+     * @param obj the JSON object to scan
+     * @param objPath the current path in the JSON tree (pass [JsonPointer.empty] for root)
+     * @param foundReferences output map that will be mutated with discovered references
+     */
     fun findReferenceFieldsRecursively(
         obj: JsonObject,
         objPath: JsonPointer,

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/SchemaTypeResolver.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/SchemaTypeResolver.kt
@@ -59,21 +59,13 @@ object SchemaTypeResolver {
      * @param parentClassName Optional parent class name for nested schemas
      * @return A Kotlin type name representing the schema
      */
-    /**
-     * Resolves the Kotlin type for a schema.
-     *
-     * @param schema The schema to resolve
-     * @param packageName The package for the type
-     * @param role The role of the property
-     * @param fallbackTitle The fallback title for the type
-     * @return The resolved Kotlin type name
-     */
     fun resolveSchemaType(
         dataSchema: SingleDataSchema,
         packageName: String,
         role: PropertyRole,
         fieldName: String? = null,
-        parentClassName: String? = null
+        parentClassName: String? = null,
+        tmRefUrl: String? = null
     ): TypeName {
         val schemaTitle = selectSchemaName(dataSchema.title.getOrNull()?.toString(), fieldName)
         return when (dataSchema.type.get()) {
@@ -84,7 +76,8 @@ object SchemaTypeResolver {
                 packageName,
                 DataSchemaType.INTEGER,
                 role,
-                parentClassName = parentClassName
+                parentClassName = parentClassName,
+                tmRefUrl = tmRefUrl
             )
             DataSchemaType.NUMBER -> wrapperTypeChecker.checkForWrapperType(
                 dataSchema,
@@ -92,7 +85,8 @@ object SchemaTypeResolver {
                 packageName,
                 DataSchemaType.NUMBER,
                 role,
-                parentClassName = parentClassName
+                parentClassName = parentClassName,
+                tmRefUrl = tmRefUrl
             )
             DataSchemaType.STRING -> wrapperTypeChecker.checkForWrapperType(
                 dataSchema,
@@ -100,7 +94,8 @@ object SchemaTypeResolver {
                 packageName,
                 DataSchemaType.STRING,
                 role,
-                parentClassName = parentClassName
+                parentClassName = parentClassName,
+                tmRefUrl = tmRefUrl
             )
             DataSchemaType.OBJECT -> {
                 if ((dataSchema as ObjectSchema).enum.isNotEmpty()) {
@@ -110,7 +105,8 @@ object SchemaTypeResolver {
                         packageName,
                         DataSchemaType.OBJECT,
                         role,
-                        parentClassName = parentClassName
+                        parentClassName = parentClassName,
+                        tmRefUrl = tmRefUrl
                     )
                 }else{
                     classGenerator.generateClassFrom(
@@ -118,13 +114,14 @@ object SchemaTypeResolver {
                         dataSchema,
                         packageName,
                         role,
-                        parentClassName = parentClassName
+                        parentClassName = parentClassName,
+                        tmRefUrl = tmRefUrl
                     )
                 }
 
             }
 
-            DataSchemaType.ARRAY -> resolveArraySchemaType(dataSchema as ArraySchema, packageName, role, schemaTitle!!)
+            DataSchemaType.ARRAY -> resolveArraySchemaType(dataSchema as ArraySchema, packageName, role, schemaTitle!!, tmRefUrl)
             DataSchemaType.NULL -> UNIT.copy(nullable = true)
         }
     }
@@ -144,25 +141,15 @@ object SchemaTypeResolver {
      * @param fallbackTitle Fallback title for naming
      * @return A Kotlin type name representing List<T>
      */
-    /**
-     * Resolves the Kotlin type for an array schema.
-     *
-     * @param arraySchema The array schema to resolve
-     * @param packageName The package for the type
-     * @param role The role of the property
-     * @param fallbackTitle The fallback title for the type
-     * @return The resolved Kotlin type name
-     */
-    fun resolveArraySchemaType(arraySchema: ArraySchema, packageName: String, role: PropertyRole, fallbackTitle: String): TypeName {
-        logger.debug("Resolving array items schema: ${arraySchema.toJson()}")
+    fun resolveArraySchemaType(arraySchema: ArraySchema, packageName: String, role: PropertyRole, fallbackTitle: String, tmRefUrl: String? = null): TypeName {
         val arrayName = arraySchema.title.getOrNull()?.toString() ?: fallbackTitle
         val parametrizedType = arraySchema.items.get().let {
             when (it) {
-                is ArraySchema -> resolveArraySchemaType(it, arrayName, role, "${fallbackTitle}Array")
+                is ArraySchema -> resolveArraySchemaType(it, arrayName, role, "${fallbackTitle}Array", tmRefUrl)
                 // Note that ObjectSchema is SingleDataSchema, so we first need to
                 // check for ObjectSchema as it is more specific
-                is ObjectSchema -> classGenerator.generateClassFrom("${arrayName}Item", it, packageName, role, parentClassName = arrayName)
-                is SingleDataSchema -> resolveSchemaType(it, packageName, role, parentClassName = arrayName)
+                is ObjectSchema -> classGenerator.generateClassFrom("${arrayName}Item", it, packageName, role, parentClassName = arrayName, tmRefUrl = tmRefUrl)
+                is SingleDataSchema -> resolveSchemaType(it, packageName, role, parentClassName = arrayName, tmRefUrl = tmRefUrl)
                 else -> {
                     throw IllegalArgumentException("Unsupported type for array items")
                 }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/TmRefScanner.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/TmRefScanner.kt
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.property
+
+import org.eclipse.ditto.json.JsonArray
+import org.eclipse.ditto.json.JsonFactory
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.json.JsonPointer
+import org.eclipse.ditto.json.JsonValue
+import kotlin.jvm.optionals.getOrNull
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.SharedTypeRegistry
+import org.eclipse.ditto.wot.kotlin.generator.plugin.util.loadJson
+import org.eclipse.ditto.wot.kotlin.generator.plugin.util.readJsonValue
+import org.slf4j.LoggerFactory
+import java.util.Collections
+
+/**
+ * Pre-scans a Thing Model's raw JSON to build a mapping of structural fingerprint → tm:ref URL.
+ * The fingerprint captures the schema's shape (property names, types, required, enum values)
+ * while ignoring metadata (titles, descriptions) that the WoT library may rewrite.
+ *
+ * **Thread safety:** Uses a thread-safe set for visited URLs. Currently single-threaded in the
+ * Maven plugin, but safe if used programmatically in a concurrent context.
+ */
+object TmRefScanner {
+
+    private val logger = LoggerFactory.getLogger(TmRefScanner::class.java)
+    private val visitedUrls: MutableSet<String> = Collections.newSetFromMap(java.util.concurrent.ConcurrentHashMap())
+
+    /**
+     * Pre-scans the raw Thing Model JSON at [modelUrl], recursively following all `tm:ref`,
+     * `tm:submodel`, and `tm:extends` links. For each `tm:ref` target, computes a structural
+     * fingerprint and registers it in [SharedTypeRegistry] so the generator can later identify
+     * which resolved schema came from which `tm:ref`.
+     *
+     * Must be called before `DittoBasedWotLoader.load()`, which discards `tm:ref` URLs.
+     */
+    fun scan(modelUrl: String) {
+        visitedUrls.clear()
+        SharedTypeRegistry.clearRefMappings()
+        val json = loadJson(modelUrl)
+        scanJson(json)
+        SharedTypeRegistry.markConflictingTitles()
+    }
+
+    private fun scanJson(json: JsonObject) {
+        val refs = ReferencePropertyResolver.collectReferenceFields(json)
+
+        for ((_, refUrl) in refs) {
+            val cleanUrl = refUrl.replace("\"", "")
+            // Always count every reference, even if already visited
+            SharedTypeRegistry.incrementRefCount(cleanUrl)
+            if (cleanUrl in visitedUrls) continue
+            visitedUrls.add(cleanUrl)
+
+            try {
+                val hashCount = cleanUrl.count { it == '#' }
+                if (hashCount != 1) continue
+
+                val parts = cleanUrl.split("#", limit = 2)
+                val baseUrl = parts[0]
+                val fragmentPath = parts[1]
+
+                val refJson = loadJson(baseUrl)
+                val resolvedContent = readJsonValue(refJson, JsonPointer.of(fragmentPath))
+
+                if (resolvedContent != null && resolvedContent.isObject) {
+                    val resolvedObj = resolvedContent.asObject()
+                    val fingerprint = computeFingerprint(resolvedObj)
+                    SharedTypeRegistry.registerRefMapping(fingerprint, cleanUrl)
+                    val title = resolvedObj.getValue("title").getOrNull()
+                    if (title != null && title.isString) {
+                        SharedTypeRegistry.registerRefTitle(cleanUrl, title.asString())
+                    }
+                    logger.debug("Registered tm:ref fingerprint for {}", cleanUrl)
+
+                    scanJson(refJson)
+                }
+            } catch (e: Exception) {
+                logger.warn("Could not scan tm:ref $cleanUrl: ${e.message}")
+            }
+        }
+
+        val linksValue = json.getValue(JsonPointer.of("links")).getOrNull()
+        if (linksValue != null && linksValue.isArray) {
+            for (link in linksValue.asArray()) {
+                if (link.isObject) {
+                    val linkObj = link.asObject()
+                    val rel = linkObj.getValue("rel").getOrNull()?.asString()
+                    val href = linkObj.getValue("href").getOrNull()?.asString()
+                    if ((rel == "tm:submodel" || rel == "tm:extends") && href != null && href !in visitedUrls) {
+                        visitedUrls.add(href)
+                        try {
+                            scanJson(loadJson(href))
+                        } catch (e: Exception) {
+                            logger.warn("Could not scan $rel link $href: ${e.message}")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Computes a structural fingerprint of a JSON schema.
+     * Captures the supported schema subset relevant for code generation and deduplication.
+     * Ignores: title, description, @type, unit, readOnly, default, format, ditto:category.
+     */
+    fun computeFingerprint(schema: JsonObject): String {
+        return extractSchemaFingerprint(schema).toJson().toString()
+    }
+
+    private fun extractSchemaFingerprint(schema: JsonObject): SchemaFingerprint {
+        return SchemaFingerprint(
+            type = schema.value("type")?.let(::canonicalizeJsonValue),
+            objectSchema = extractObjectSchemaFingerprint(schema),
+            arraySchema = extractArraySchemaFingerprint(schema),
+            stringSchema = extractStringSchemaFingerprint(schema),
+            numericSchema = extractNumericSchemaFingerprint(schema),
+            enumValues = extractSortedValueArray(schema, "enum"),
+            constValue = schema.value("const")?.let(::canonicalizeJsonValue),
+            oneOf = extractCompositionSchemas(schema, "oneOf"),
+            anyOf = extractCompositionSchemas(schema, "anyOf"),
+            allOf = extractCompositionSchemas(schema, "allOf")
+        )
+    }
+
+    private fun extractCompositionSchemas(schema: JsonObject, key: String): List<SchemaFingerprint> {
+        val value = schema.value(key) ?: return emptyList()
+        if (!value.isArray) return emptyList()
+        return value.asArray().mapNotNull { item ->
+            item.takeIf(JsonValue::isObject)?.asObject()?.let(::extractSchemaFingerprint)
+        }
+    }
+
+    private fun extractObjectSchemaFingerprint(schema: JsonObject): ObjectSchemaFingerprint? {
+        val properties = extractSchemaMap(schema, "properties")
+        val required = extractSortedStringArray(schema, "required")
+        val additionalProperties = schema.value("additionalProperties")?.let(::extractAdditionalPropertiesFingerprint)
+        val patternProperties = extractSchemaMap(schema, "patternProperties")
+        val minProperties = schema.value("minProperties")?.let(::canonicalizeJsonValue)
+        val maxProperties = schema.value("maxProperties")?.let(::canonicalizeJsonValue)
+
+        return ObjectSchemaFingerprint(
+            properties = properties,
+            required = required,
+            additionalProperties = additionalProperties,
+            patternProperties = patternProperties,
+            minProperties = minProperties,
+            maxProperties = maxProperties
+        ).takeIf(ObjectSchemaFingerprint::isNotEmpty)
+    }
+
+    private fun extractArraySchemaFingerprint(schema: JsonObject): ArraySchemaFingerprint? {
+        val itemsValue = schema.value("items")
+        val singleItem = itemsValue?.takeIf(JsonValue::isObject)?.asObject()?.let(::extractSchemaFingerprint)
+        val tupleItems = itemsValue?.takeIf(JsonValue::isArray)
+            ?.asArray()
+            ?.mapNotNull { item ->
+                item.takeIf(JsonValue::isObject)?.asObject()?.let(::extractSchemaFingerprint)
+            }
+            .orEmpty()
+        val minItems = schema.value("minItems")?.let(::canonicalizeJsonValue)
+        val maxItems = schema.value("maxItems")?.let(::canonicalizeJsonValue)
+        val uniqueItems = schema.value("uniqueItems")?.let(::canonicalizeJsonValue)
+
+        return ArraySchemaFingerprint(
+            singleItem = singleItem,
+            tupleItems = tupleItems,
+            minItems = minItems,
+            maxItems = maxItems,
+            uniqueItems = uniqueItems
+        ).takeIf(ArraySchemaFingerprint::isNotEmpty)
+    }
+
+    private fun extractStringSchemaFingerprint(schema: JsonObject): StringSchemaFingerprint? {
+        return StringSchemaFingerprint(
+            minLength = schema.value("minLength")?.let(::canonicalizeJsonValue),
+            maxLength = schema.value("maxLength")?.let(::canonicalizeJsonValue),
+            pattern = schema.value("pattern")?.let(::canonicalizeJsonValue)
+        ).takeIf(StringSchemaFingerprint::isNotEmpty)
+    }
+
+    private fun extractNumericSchemaFingerprint(schema: JsonObject): NumericSchemaFingerprint? {
+        return NumericSchemaFingerprint(
+            minimum = schema.value("minimum")?.let(::canonicalizeJsonValue),
+            maximum = schema.value("maximum")?.let(::canonicalizeJsonValue),
+            multipleOf = schema.value("multipleOf")?.let(::canonicalizeJsonValue)
+        ).takeIf(NumericSchemaFingerprint::isNotEmpty)
+    }
+
+    private fun extractAdditionalPropertiesFingerprint(value: JsonValue): AdditionalPropertiesFingerprint {
+        return when {
+            value.isObject -> AdditionalPropertiesSchemaFingerprint(extractSchemaFingerprint(value.asObject()))
+            else -> AdditionalPropertiesFlagFingerprint(canonicalizeJsonValue(value))
+        }
+    }
+
+    private fun extractSchemaMap(schema: JsonObject, key: String): Map<String, SchemaFingerprint> {
+        val value = schema.value(key) ?: return emptyMap()
+        if (!value.isObject) return emptyMap()
+
+        val obj = value.asObject()
+        return obj.keys.map { it.toString() }.sorted().associateWith { fieldName ->
+            extractSchemaFingerprint(obj.getField(fieldName).getOrNull()!!.value.asObject())
+        }
+    }
+
+    private fun extractSortedStringArray(schema: JsonObject, key: String): List<String> {
+        val value = schema.value(key) ?: return emptyList()
+        if (!value.isArray) return emptyList()
+        return value.asArray().map(JsonValue::toString).sorted()
+    }
+
+    private fun extractSortedValueArray(schema: JsonObject, key: String): List<JsonValue> {
+        val value = schema.value(key) ?: return emptyList()
+        if (!value.isArray) return emptyList()
+        return value.asArray().map(::canonicalizeJsonValue).sortedBy(JsonValue::toString)
+    }
+
+    private fun SchemaFingerprint.toJson(): JsonObject {
+        val builder = JsonFactory.newObjectBuilder()
+        type?.let { builder.set("type", it) }
+        objectSchema?.let { builder.set("object", it.toJson()) }
+        arraySchema?.let { builder.set("array", it.toJson()) }
+        stringSchema?.let { builder.set("string", it.toJson()) }
+        numericSchema?.let { builder.set("numeric", it.toJson()) }
+        if (enumValues.isNotEmpty()) {
+            builder.set("enum", JsonFactory.newArrayBuilder().apply { enumValues.forEach(::add) }.build())
+        }
+        constValue?.let { builder.set("const", it) }
+        if (oneOf.isNotEmpty()) {
+            builder.set("oneOf", JsonFactory.newArrayBuilder().apply { oneOf.forEach { add(it.toJson()) } }.build())
+        }
+        if (anyOf.isNotEmpty()) {
+            builder.set("anyOf", JsonFactory.newArrayBuilder().apply { anyOf.forEach { add(it.toJson()) } }.build())
+        }
+        if (allOf.isNotEmpty()) {
+            builder.set("allOf", JsonFactory.newArrayBuilder().apply { allOf.forEach { add(it.toJson()) } }.build())
+        }
+        return builder.build()
+    }
+
+    private fun ObjectSchemaFingerprint.toJson(): JsonObject {
+        val builder = JsonFactory.newObjectBuilder()
+        if (properties.isNotEmpty()) {
+            builder.set("properties", JsonFactory.newObjectBuilder().apply {
+                properties.forEach { (name, propertySchema) -> set(name, propertySchema.toJson()) }
+            }.build())
+        }
+        if (required.isNotEmpty()) {
+            builder.set("required", JsonFactory.newArrayBuilder().apply { required.forEach(::add) }.build())
+        }
+        additionalProperties?.let { builder.set("additionalProperties", it.toJsonValue()) }
+        if (patternProperties.isNotEmpty()) {
+            builder.set("patternProperties", JsonFactory.newObjectBuilder().apply {
+                patternProperties.forEach { (patternKey, propertySchema) -> set(patternKey, propertySchema.toJson()) }
+            }.build())
+        }
+        minProperties?.let { builder.set("minProperties", it) }
+        maxProperties?.let { builder.set("maxProperties", it) }
+        return builder.build()
+    }
+
+    private fun ArraySchemaFingerprint.toJson(): JsonObject {
+        val builder = JsonFactory.newObjectBuilder()
+        singleItem?.let { builder.set("items", it.toJson()) }
+        if (tupleItems.isNotEmpty()) {
+            builder.set("tupleItems", JsonFactory.newArrayBuilder().apply {
+                tupleItems.forEach { add(it.toJson()) }
+            }.build())
+        }
+        minItems?.let { builder.set("minItems", it) }
+        maxItems?.let { builder.set("maxItems", it) }
+        uniqueItems?.let { builder.set("uniqueItems", it) }
+        return builder.build()
+    }
+
+    private fun StringSchemaFingerprint.toJson(): JsonObject {
+        val builder = JsonFactory.newObjectBuilder()
+        minLength?.let { builder.set("minLength", it) }
+        maxLength?.let { builder.set("maxLength", it) }
+        pattern?.let { builder.set("pattern", it) }
+        return builder.build()
+    }
+
+    private fun NumericSchemaFingerprint.toJson(): JsonObject {
+        val builder = JsonFactory.newObjectBuilder()
+        minimum?.let { builder.set("minimum", it) }
+        maximum?.let { builder.set("maximum", it) }
+        multipleOf?.let { builder.set("multipleOf", it) }
+        return builder.build()
+    }
+
+    private fun canonicalizeJsonValue(value: JsonValue): JsonValue {
+        return when {
+            value.isObject -> canonicalizeJsonObject(value.asObject())
+            value.isArray -> canonicalizeJsonArray(value.asArray())
+            else -> value
+        }
+    }
+
+    private fun canonicalizeJsonObject(jsonObject: JsonObject): JsonObject {
+        val builder = JsonFactory.newObjectBuilder()
+        jsonObject.keys.map { it.toString() }.sorted().forEach { key ->
+            jsonObject.getField(key).getOrNull()?.value?.let { fieldValue ->
+                builder.set(key, canonicalizeJsonValue(fieldValue))
+            }
+        }
+        return builder.build()
+    }
+
+    private fun canonicalizeJsonArray(array: JsonArray): JsonArray {
+        val builder = JsonFactory.newArrayBuilder()
+        array.forEach { builder.add(canonicalizeJsonValue(it)) }
+        return builder.build()
+    }
+
+    private fun JsonObject.value(key: String): JsonValue? = getValue(JsonPointer.of(key)).getOrNull()
+
+    private data class SchemaFingerprint(
+        val type: JsonValue? = null,
+        val objectSchema: ObjectSchemaFingerprint? = null,
+        val arraySchema: ArraySchemaFingerprint? = null,
+        val stringSchema: StringSchemaFingerprint? = null,
+        val numericSchema: NumericSchemaFingerprint? = null,
+        val enumValues: List<JsonValue> = emptyList(),
+        val constValue: JsonValue? = null,
+        val oneOf: List<SchemaFingerprint> = emptyList(),
+        val anyOf: List<SchemaFingerprint> = emptyList(),
+        val allOf: List<SchemaFingerprint> = emptyList()
+    )
+
+    private data class ObjectSchemaFingerprint(
+        val properties: Map<String, SchemaFingerprint> = emptyMap(),
+        val required: List<String> = emptyList(),
+        val additionalProperties: AdditionalPropertiesFingerprint? = null,
+        val patternProperties: Map<String, SchemaFingerprint> = emptyMap(),
+        val minProperties: JsonValue? = null,
+        val maxProperties: JsonValue? = null
+    ) {
+        fun isNotEmpty(): Boolean {
+            return properties.isNotEmpty() ||
+                required.isNotEmpty() ||
+                additionalProperties != null ||
+                patternProperties.isNotEmpty() ||
+                minProperties != null ||
+                maxProperties != null
+        }
+    }
+
+    private data class ArraySchemaFingerprint(
+        val singleItem: SchemaFingerprint? = null,
+        val tupleItems: List<SchemaFingerprint> = emptyList(),
+        val minItems: JsonValue? = null,
+        val maxItems: JsonValue? = null,
+        val uniqueItems: JsonValue? = null
+    ) {
+        fun isNotEmpty(): Boolean {
+            return singleItem != null ||
+                tupleItems.isNotEmpty() ||
+                minItems != null ||
+                maxItems != null ||
+                uniqueItems != null
+        }
+    }
+
+    private data class StringSchemaFingerprint(
+        val minLength: JsonValue? = null,
+        val maxLength: JsonValue? = null,
+        val pattern: JsonValue? = null
+    ) {
+        fun isNotEmpty(): Boolean = minLength != null || maxLength != null || pattern != null
+    }
+
+    private data class NumericSchemaFingerprint(
+        val minimum: JsonValue? = null,
+        val maximum: JsonValue? = null,
+        val multipleOf: JsonValue? = null
+    ) {
+        fun isNotEmpty(): Boolean = minimum != null || maximum != null || multipleOf != null
+    }
+
+    private sealed interface AdditionalPropertiesFingerprint {
+        fun toJsonValue(): JsonValue
+    }
+
+    private data class AdditionalPropertiesSchemaFingerprint(
+        val schema: SchemaFingerprint
+    ) : AdditionalPropertiesFingerprint {
+        override fun toJsonValue(): JsonValue = schema.toJson()
+    }
+
+    private data class AdditionalPropertiesFlagFingerprint(
+        val value: JsonValue
+    ) : AdditionalPropertiesFingerprint {
+        override fun toJsonValue(): JsonValue = value
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/WrapperTypeChecker.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/WrapperTypeChecker.kt
@@ -14,14 +14,18 @@ package org.eclipse.ditto.wot.kotlin.generator.plugin.property
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeName
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.ClassGenerator
 import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.EnumGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.SharedTypeRegistry
 import org.eclipse.ditto.wot.kotlin.generator.plugin.strategy.IEnumGenerationStrategy
+import org.slf4j.LoggerFactory
 import org.eclipse.ditto.wot.kotlin.generator.plugin.util.asPrimitiveClassName
 import org.eclipse.ditto.wot.model.DataSchemaType
 import org.eclipse.ditto.wot.model.SingleDataSchema
 
 object WrapperTypeChecker {
 
+    private val logger = LoggerFactory.getLogger(WrapperTypeChecker::class.java)
     private val enumGenerator = EnumGenerator
     private var enumGenerationStrategy: IEnumGenerationStrategy? = null
 
@@ -37,19 +41,20 @@ object WrapperTypeChecker {
         role: PropertyRole,
         feature: String? = null,
         dittoCategory: String? = null,
-        parentClassName: String? = null
+        parentClassName: String? = null,
+        tmRefUrl: String? = null
     ): TypeName {
         val enumArray = propertySchema.enum
 
         return when {
             (schemaType == DataSchemaType.OBJECT || enumArray?.isNotEmpty() == true) -> {
                 val enumKey = if (enumGenerationStrategy != null) {
-                    enumGenerationStrategy!!.generateEnum(propertySchema, propertyName, enumArray ?: mutableSetOf(), schemaType, propertyPackage, parentClassName)
+                    enumGenerationStrategy!!.generateEnum(propertySchema, propertyName, enumArray ?: mutableSetOf(), schemaType, propertyPackage, parentClassName, tmRefUrl)
                 } else {
                     enumGenerator.generateEnum(propertySchema, propertyName, enumArray ?: mutableSetOf(), schemaType, parentClassName)
                 }
 
-                val isInlineStrategy = enumGenerationStrategy?.javaClass?.simpleName == "InlineEnumGenerationStrategy"
+                val isInlineStrategy = enumGenerationStrategy?.isInline == true
 
                 val enumName = if (isInlineStrategy) {
                     enumKey
@@ -60,7 +65,20 @@ object WrapperTypeChecker {
                 val enumClassName = if (isInlineStrategy) {
                     ClassName("", enumName)
                 } else {
-                    ClassName(propertyPackage, enumName)
+                    val config = ClassGenerator.getConfig()
+                    if (config?.deduplicateReferencedTypes == true) {
+                        val resolved = SharedTypeRegistry.findExistingEnumByNameInPackage(enumName, propertyPackage)
+                            ?: SharedTypeRegistry.findExistingEnumByName(enumName)
+                        if (resolved != null) {
+                            logger.debug("Resolved dedup enum '{}' in {} to {}", enumName, propertyPackage, resolved.canonicalName)
+                            resolved
+                        } else {
+                            logger.debug("No dedup match for enum '{}' in {}, using local package", enumName, propertyPackage)
+                            ClassName(propertyPackage, enumName)
+                        }
+                    } else {
+                        ClassName(propertyPackage, enumName)
+                    }
                 }
 
                 enumClassName.copy(nullable = true)

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/EnumBuilderHelper.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/EnumBuilderHelper.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.strategy
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.squareup.kotlinpoet.*
+import org.eclipse.ditto.wot.kotlin.generator.plugin.util.asEnumConstantName
+import org.eclipse.ditto.wot.kotlin.generator.plugin.util.asValidEnumConstant
+import com.fasterxml.jackson.annotation.JsonValue as JacksonJsonValue
+
+/**
+ * Shared helper methods for building enum type specs, used by both
+ * [InlineEnumGenerationStrategy] and [SeparateClassEnumGenerationStrategy].
+ */
+object EnumBuilderHelper {
+
+    fun buildToValueFunc(valueType: TypeName): FunSpec {
+        return FunSpec.builder("toValue")
+            .addAnnotation(JacksonJsonValue::class)
+            .returns(valueType)
+            .addCode("return _value")
+            .build()
+    }
+
+    fun buildFromValueFunc(enumClassName: ClassName, valueType: TypeName): FunSpec {
+        return FunSpec.builder("fromValue")
+            .addAnnotation(JsonCreator::class)
+            .returns(enumClassName.copy(nullable = true))
+            .addParameter("v", valueType.copy(nullable = true))
+            .addCode("return entries.firstOrNull { it._value == v }")
+            .build()
+    }
+
+    fun buildFromNameFunc(enumClassName: ClassName): FunSpec {
+        return FunSpec.builder("fromName")
+            .returns(enumClassName.copy(nullable = true))
+            .addParameter("name", String::class.asTypeName().copy(nullable = true))
+            .addCode("return entries.firstOrNull { it.name == name }")
+            .build()
+    }
+
+    fun addCustomEnumConstants(
+        enumSpecBuilder: TypeSpec.Builder,
+        enumName: String,
+        enumValues: List<Any>,
+        valueType: TypeName,
+        useSeparateClassNaming: Boolean
+    ) {
+        enumValues.forEach {
+            val constantName = if (useSeparateClassNaming) {
+                asEnumConstantName(enumName, it.toString())
+            } else {
+                asValidEnumConstant(it.toString())
+            }
+            enumSpecBuilder.addEnumConstant(
+                constantName,
+                TypeSpec.anonymousClassBuilder()
+                    .addSuperclassConstructorParameter(
+                        if (valueType == STRING) "%S" else "%L",
+                        it
+                    )
+                    .build()
+            )
+        }
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/IEnumGenerationStrategy.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/IEnumGenerationStrategy.kt
@@ -24,6 +24,9 @@ import org.eclipse.ditto.wot.model.SingleDataSchema
  */
 interface IEnumGenerationStrategy {
 
+    /** Whether this strategy generates enums inline within the containing class. */
+    val isInline: Boolean
+
     /**
      * Generates an enum from a schema.
      *
@@ -40,7 +43,8 @@ interface IEnumGenerationStrategy {
         enumArray: MutableSet<JsonValue>,
         schemaType: DataSchemaType,
         packageName: String = "",
-        parentClassName: String? = null
+        parentClassName: String? = null,
+        tmRefUrl: String? = null
     ): String
 
     /**

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/InlineEnumGenerationStrategy.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/InlineEnumGenerationStrategy.kt
@@ -25,14 +25,7 @@ import org.eclipse.ditto.wot.model.DataSchemaType
 import org.eclipse.ditto.wot.model.ObjectSchema
 import org.eclipse.ditto.wot.model.SingleDataSchema
 import kotlin.jvm.optionals.getOrNull
-import com.fasterxml.jackson.annotation.JsonValue as JacksonJsonValue
 
-/**
- * Inline enum generation strategy.
- *
- * This strategy maintains the current behavior where enums are generated
- * as inline classes nested within the classes that use them.
- */
 /**
  * Strategy for generating enums inline within classes.
  *
@@ -40,6 +33,8 @@ import com.fasterxml.jackson.annotation.JsonValue as JacksonJsonValue
  * which helps reduce the number of generated files and keeps related code together.
  */
 class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
+
+    override val isInline: Boolean = true
 
     private val classGenerator = ClassGenerator
 
@@ -49,7 +44,8 @@ class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
         enumArray: MutableSet<JsonValue>,
         schemaType: DataSchemaType,
         packageName: String,
-        parentClassName: String?
+        parentClassName: String?,
+        tmRefUrl: String?
     ): String {
         val enumName = if (propertyName != null) {
             asClassName(propertyName)
@@ -284,7 +280,7 @@ class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
             val adjustedPropertyName = asPropertyName(propertyName)
             val typeName = asPrimitiveClassName(schema)
             companionBuilder.addFunction(
-                FunSpec.builder("from${adjustedPropertyName.capitalize()}")
+                FunSpec.builder("from${adjustedPropertyName.replaceFirstChar { it.titlecase() }}")
                     .returns(enumClassName.copy(nullable = true))
                     .addParameter(adjustedPropertyName, typeName.copy(nullable = true))
                     .addCode("return INSTANCES.firstOrNull { it.$adjustedPropertyName == $adjustedPropertyName }")
@@ -340,47 +336,14 @@ class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
         return enumKey
     }
 
-    private fun buildToValueFunc(valueType: TypeName): FunSpec {
-        return FunSpec.builder("toValue")
-            .addAnnotation(JacksonJsonValue::class)
-            .returns(valueType)
-            .addCode("return _value")
-            .build()
-    }
-
-    private fun buildFromValueFunc(enumClassName: ClassName, valueType: TypeName): FunSpec {
-        return FunSpec.builder("fromValue")
-            .addAnnotation(JsonCreator::class)
-            .returns(enumClassName.copy(nullable = true))
-            .addParameter("v", valueType.copy(nullable = true))
-            .addCode("return entries.firstOrNull { it._value == v }")
-            .build()
-    }
-
-    private fun buildFromNameFunc(enumClassName: ClassName): FunSpec {
-        return FunSpec.builder("fromName")
-            .returns(enumClassName.copy(nullable = true))
-            .addParameter("name", String::class.asTypeName().copy(nullable = true))
-            .addCode("return entries.firstOrNull { it.name == name }")
-            .build()
-    }
+    private fun buildToValueFunc(valueType: TypeName) = EnumBuilderHelper.buildToValueFunc(valueType)
+    private fun buildFromValueFunc(enumClassName: ClassName, valueType: TypeName) = EnumBuilderHelper.buildFromValueFunc(enumClassName, valueType)
+    private fun buildFromNameFunc(enumClassName: ClassName) = EnumBuilderHelper.buildFromNameFunc(enumClassName)
 
     private fun addCustomEnumConstants(
         enumSpecBuilder: TypeSpec.Builder,
         enumName: String,
         enumValues: List<Any>,
         valueType: TypeName
-    ) {
-        enumValues.forEach {
-            enumSpecBuilder.addEnumConstant(
-                asValidEnumConstant(it.toString()),
-                TypeSpec.anonymousClassBuilder()
-                    .addSuperclassConstructorParameter(
-                        if (valueType == STRING) "%S" else "%L",
-                        it
-                    )
-                    .build()
-            )
-        }
-    }
+    ) = EnumBuilderHelper.addCustomEnumConstants(enumSpecBuilder, enumName, enumValues, valueType, useSeparateClassNaming = false)
 }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/SeparateClassEnumGenerationStrategy.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/SeparateClassEnumGenerationStrategy.kt
@@ -20,12 +20,13 @@ import org.eclipse.ditto.json.JsonValue
 import org.eclipse.ditto.wot.kotlin.generator.common.model.enum.JsonEnum
 import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.ClassGenerator
 import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.EnumRegistry
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.SharedTypeRegistry
 import org.eclipse.ditto.wot.kotlin.generator.plugin.util.*
+import org.slf4j.LoggerFactory
 import org.eclipse.ditto.wot.model.DataSchemaType
 import org.eclipse.ditto.wot.model.ObjectSchema
 import org.eclipse.ditto.wot.model.SingleDataSchema
 import kotlin.jvm.optionals.getOrNull
-import com.fasterxml.jackson.annotation.JsonValue as JacksonJsonValue
 
 /**
  * Strategy for generating enums as separate class files.
@@ -35,7 +36,10 @@ import com.fasterxml.jackson.annotation.JsonValue as JacksonJsonValue
  */
 class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
 
+    override val isInline: Boolean = false
+
     private val classGenerator = ClassGenerator
+    private val logger = LoggerFactory.getLogger(SeparateClassEnumGenerationStrategy::class.java)
 
     override fun generateEnum(
         propertySchema: SingleDataSchema?,
@@ -43,7 +47,8 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         enumArray: MutableSet<JsonValue>,
         schemaType: DataSchemaType,
         packageName: String,
-        parentClassName: String?
+        parentClassName: String?,
+        tmRefUrl: String?
     ): String {
         val config = classGenerator.getConfig()
         val enumName = try {
@@ -56,23 +61,60 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
             asClassName(propertyName ?: "Enum")
         }
         val enumValues = asListOf(enumArray, schemaType)
-        return when (schemaType) {
+        val enumConstantNames = buildEnumConstantNames(enumName, enumValues, enumArray, schemaType)
+
+        if (config != null && config.deduplicateReferencedTypes && tmRefUrl != null) {
+            val existing = SharedTypeRegistry.findEnumByRef(tmRefUrl)
+            if (existing != null) {
+                logger.debug("Dedup: Reusing enum {} for '{}' via tm:ref {}", existing.canonicalName, enumName, tmRefUrl)
+                // Register the existing enum's ClassName for the current package so
+                // WrapperTypeChecker can resolve the cross-package reference
+                SharedTypeRegistry.registerEnumAlias(packageName, enumName, existing)
+                return existing.simpleName!!
+            }
+        }
+
+        if (config?.deduplicateReferencedTypes == true) {
+            val existing = SharedTypeRegistry.findExistingEnum(enumConstantNames, schemaType)
+            if (existing != null && existing.simpleName == enumName) {
+                logger.debug("Dedup: Reusing enum {} for '{}' (same values)", existing.canonicalName, enumName)
+                SharedTypeRegistry.registerEnumAlias(packageName, enumName, existing)
+                return existing.simpleName!!
+            }
+        }
+
+        val resolvedEnumName = resolveEnumNameConflict(
+            enumName,
+            enumConstantNames,
+            packageName,
+            parentClassName,
+            config?.deduplicateReferencedTypes == true
+        )
+            ?: return enumName
+
+        val result = when (schemaType) {
             DataSchemaType.INTEGER -> generateEnumWithProperty(
-                enumName,
+                resolvedEnumName,
                 enumValues,
                 LONG,
                 packageName
             )
             DataSchemaType.NUMBER -> generateEnumWithProperty(
-                enumName,
+                resolvedEnumName,
                 enumValues,
                 DOUBLE,
                 packageName
             )
-            DataSchemaType.STRING -> generateStringEnum(enumName, enumValues, packageName)
-            DataSchemaType.OBJECT -> generateObjectEnum(propertySchema as ObjectSchema, enumName, enumArray, packageName)
+            DataSchemaType.STRING -> generateStringEnum(resolvedEnumName, enumValues, packageName)
+            DataSchemaType.OBJECT -> generateObjectEnum(propertySchema as ObjectSchema, resolvedEnumName, enumArray, packageName)
             else -> throw IllegalArgumentException("Unsupported type for enum property $schemaType")
         }
+
+        if (config?.deduplicateReferencedTypes == true && tmRefUrl != null) {
+            SharedTypeRegistry.registerEnumByRef(tmRefUrl, ClassName(packageName, result))
+        }
+
+        return result
     }
 
     override fun generateActionEnum(
@@ -125,6 +167,7 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
     }
 
     private fun generateStringEnum(enumName: String, enumValues: List<Any>, packageName: String): String {
+        val config = classGenerator.getConfig()
         val firstEnumValue = enumValues.first().toString()
         val isSimpleEnum = asEnumConstantName(enumName, firstEnumValue) == firstEnumValue
 
@@ -169,6 +212,10 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         EnumRegistry.registerEnum(enumSpec, packageName, enumConstantNames)
         ClassGenerator.generateNewClass(enumSpec, enumName, packageName)
 
+        if (config?.deduplicateReferencedTypes == true) {
+            SharedTypeRegistry.registerEnum(enumConstantNames, DataSchemaType.STRING, ClassName(packageName, enumName))
+        }
+
         return enumName
     }
 
@@ -178,6 +225,7 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         valueType: TypeName,
         packageName: String
     ): String {
+        val config = classGenerator.getConfig()
         val enumSpecBuilder = TypeSpec.enumBuilder(enumName)
             .primaryConstructor(
                 FunSpec.constructorBuilder()
@@ -207,6 +255,11 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         EnumRegistry.registerEnum(enumSpec, packageName, enumConstantNames)
         ClassGenerator.generateNewClass(enumSpec, enumName, packageName)
 
+        if (config?.deduplicateReferencedTypes == true) {
+            val schemaType = if (valueType == LONG) DataSchemaType.INTEGER else DataSchemaType.NUMBER
+            SharedTypeRegistry.registerEnum(enumConstantNames, schemaType, ClassName(packageName, enumName))
+        }
+
         return enumName
     }
 
@@ -216,6 +269,7 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         enumArray: MutableSet<JsonValue>,
         packageName: String
     ): String {
+        val config = classGenerator.getConfig()
         val enumSpecBuilder = TypeSpec.classBuilder(enumName)
             .addModifiers(KModifier.SEALED)
             .addSuperinterface(JsonEnum::class)
@@ -276,7 +330,7 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
             val adjustedPropertyName = asPropertyName(propertyName)
             val typeName = asPrimitiveClassName(schema)
             companionBuilder.addFunction(
-                FunSpec.builder("from${adjustedPropertyName.capitalize()}")
+                FunSpec.builder("from${adjustedPropertyName.replaceFirstChar { it.titlecase() }}")
                     .returns(enumClassName.copy(nullable = true))
                     .addParameter(adjustedPropertyName, typeName.copy(nullable = true))
                     .addCode("return INSTANCES.firstOrNull { it.$adjustedPropertyName == $adjustedPropertyName }")
@@ -336,50 +390,70 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         EnumRegistry.registerEnum(enumSpec, packageName, enumConstantNames)
         ClassGenerator.generateNewClass(enumSpec, enumName, packageName)
 
+        if (config?.deduplicateReferencedTypes == true) {
+            SharedTypeRegistry.registerEnum(enumConstantNames, DataSchemaType.OBJECT, ClassName(packageName, enumName))
+        }
+
         return enumName
     }
 
-    private fun buildToValueFunc(valueType: TypeName): FunSpec {
-        return FunSpec.builder("toValue")
-            .addAnnotation(JacksonJsonValue::class)
-            .returns(valueType)
-            .addCode("return _value")
-            .build()
-    }
-
-    private fun buildFromValueFunc(enumClassName: ClassName, valueType: TypeName): FunSpec {
-        return FunSpec.builder("fromValue")
-            .addAnnotation(JsonCreator::class)
-            .returns(enumClassName.copy(nullable = true))
-            .addParameter("v", valueType.copy(nullable = true))
-            .addCode("return entries.firstOrNull { it._value == v }")
-            .build()
-    }
-
-    private fun buildFromNameFunc(enumClassName: ClassName): FunSpec {
-        return FunSpec.builder("fromName")
-            .returns(enumClassName.copy(nullable = true))
-            .addParameter("name", String::class.asTypeName().copy(nullable = true))
-            .addCode("return entries.firstOrNull { it.name == name }")
-            .build()
-    }
+    private fun buildToValueFunc(valueType: TypeName) = EnumBuilderHelper.buildToValueFunc(valueType)
+    private fun buildFromValueFunc(enumClassName: ClassName, valueType: TypeName) = EnumBuilderHelper.buildFromValueFunc(enumClassName, valueType)
+    private fun buildFromNameFunc(enumClassName: ClassName) = EnumBuilderHelper.buildFromNameFunc(enumClassName)
 
     private fun addCustomEnumConstants(
         enumSpecBuilder: TypeSpec.Builder,
         enumName: String,
         enumValues: List<Any>,
         valueType: TypeName
-    ) {
-        enumValues.forEach {
-            enumSpecBuilder.addEnumConstant(
-                asEnumConstantName(enumName, it.toString()),
-                TypeSpec.anonymousClassBuilder()
-                    .addSuperclassConstructorParameter(
-                        if (valueType == STRING) "%S" else "%L",
-                        it
-                    )
-                    .build()
-            )
+    ) = EnumBuilderHelper.addCustomEnumConstants(enumSpecBuilder, enumName, enumValues, valueType, useSeparateClassNaming = true)
+
+    /**
+     * Resolves enum naming conflicts by prefixing with the parent class name
+     * when an enum with the same name but different values already exists.
+     * Returns null to signal "reuse existing" when values are identical (dedup).
+     */
+    private fun resolveEnumNameConflict(
+        enumName: String,
+        enumConstantNames: Set<String>,
+        packageName: String,
+        parentClassName: String?,
+        deduplicateReferencedTypes: Boolean
+    ): String? {
+        val existingEnum = EnumRegistry.getEnumByNameInPackage(enumName, packageName)
+        if (existingEnum != null) {
+            val existingConstants = EnumRegistry.getEnumValuesInPackage(packageName, enumName)
+                ?: existingEnum.enumConstants.keys.toSet()
+            if (existingConstants == enumConstantNames) {
+                if (deduplicateReferencedTypes) {
+                    logger.debug("Dedup: Reusing enum '{}' in {} (same values)", enumName, packageName)
+                    return null  // signal: reuse existing
+                }
+            }
+            if (parentClassName != null) {
+                val prefixed = "${asClassName(parentClassName)}${asClassName(enumName)}"
+                logger.debug("Enum name conflict for '$enumName' in $packageName - resolving as '$prefixed'")
+                return prefixed
+            }
+        }
+        return enumName
+    }
+
+    private fun buildEnumConstantNames(
+        enumName: String,
+        enumValues: List<Any>,
+        enumArray: MutableSet<JsonValue>,
+        schemaType: DataSchemaType
+    ): Set<String> {
+        return when (schemaType) {
+            DataSchemaType.STRING,
+            DataSchemaType.INTEGER,
+            DataSchemaType.NUMBER -> enumValues.map { asEnumConstantName(enumName, it.toString()) }.toSet()
+            DataSchemaType.OBJECT -> enumArray.map {
+                asValidEnumConstant(it.asObject().getValue("name").getOrNull().toString())
+            }.toSet()
+            else -> emptySet()
         }
     }
+
 }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/EnumRegistryTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/EnumRegistryTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.clazz
+
+import com.squareup.kotlinpoet.TypeSpec
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EnumRegistryTest {
+
+    @BeforeTest
+    fun resetState() {
+        EnumRegistry.clear()
+    }
+
+    @AfterTest
+    fun cleanupState() {
+        EnumRegistry.clear()
+    }
+
+    @Test
+    fun `package lookup keeps same enum name isolated by package`() {
+        EnumRegistry.registerEnum(
+            TypeSpec.enumBuilder("Mode").addEnumConstant("AUTO").build(),
+            "org.eclipse.ditto.pkg.one",
+            setOf("AUTO")
+        )
+        EnumRegistry.registerEnum(
+            TypeSpec.enumBuilder("Mode").addEnumConstant("MANUAL").build(),
+            "org.eclipse.ditto.pkg.two",
+            setOf("MANUAL")
+        )
+
+        assertEquals(
+            setOf("AUTO"),
+            EnumRegistry.getEnumValuesInPackage("org.eclipse.ditto.pkg.one", "Mode")
+        )
+        assertEquals(
+            setOf("MANUAL"),
+            EnumRegistry.getEnumValuesInPackage("org.eclipse.ditto.pkg.two", "Mode")
+        )
+        assertEquals(
+            setOf("AUTO"),
+            EnumRegistry.getEnumByNameInPackage("Mode", "org.eclipse.ditto.pkg.one")?.enumConstants?.keys
+        )
+        assertEquals(
+            setOf("MANUAL"),
+            EnumRegistry.getEnumByNameInPackage("Mode", "org.eclipse.ditto.pkg.two")?.enumConstants?.keys
+        )
+    }
+
+    @Test
+    fun `inline lookup does not fall back to package scoped enums`() {
+        EnumRegistry.registerEnum(
+            TypeSpec.enumBuilder("Status").addEnumConstant("OK").build(),
+            "org.eclipse.ditto.pkg.one",
+            setOf("OK")
+        )
+
+        assertNull(EnumRegistry.getInlineEnumByName("Status"))
+
+        EnumRegistry.registerEnumInline(TypeSpec.enumBuilder("Status").addEnumConstant("LOCAL").build())
+
+        assertEquals(
+            setOf("LOCAL"),
+            EnumRegistry.getInlineEnumByName("Status")?.enumConstants?.keys
+        )
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/SharedTypeRegistryTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/SharedTypeRegistryTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.clazz
+
+import com.squareup.kotlinpoet.ClassName
+import org.eclipse.ditto.json.JsonFactory
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.model.DataSchemaType
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SharedTypeRegistryTest {
+
+    @BeforeTest
+    fun resetState() {
+        SharedTypeRegistry.clear()
+        SharedTypeRegistry.clearRefMappings()
+    }
+
+    @AfterTest
+    fun cleanupState() {
+        SharedTypeRegistry.clear()
+        SharedTypeRegistry.clearRefMappings()
+    }
+
+    @Test
+    fun `exact package lookup prefers the matching package for same enum name`() {
+        SharedTypeRegistry.registerEnum(
+            setOf("AUTO"),
+            DataSchemaType.STRING,
+            ClassName("org.eclipse.ditto.pkg.one", "Mode")
+        )
+        SharedTypeRegistry.registerEnum(
+            setOf("MANUAL"),
+            DataSchemaType.STRING,
+            ClassName("org.eclipse.ditto.pkg.two", "Mode")
+        )
+
+        assertEquals(
+            "org.eclipse.ditto.pkg.one",
+            SharedTypeRegistry.findExistingEnumByNameInPackage("Mode", "org.eclipse.ditto.pkg.one")?.packageName
+        )
+        assertEquals(
+            "org.eclipse.ditto.pkg.two",
+            SharedTypeRegistry.findExistingEnumByNameInPackage("Mode", "org.eclipse.ditto.pkg.two")?.packageName
+        )
+    }
+
+    // --- Conflicting title detection tests ---
+
+    @Test
+    fun `markConflictingTitles detects two refs with same title`() {
+        val refA = "https://models.example.org/severity-2.1.1.tm.jsonld#/properties/severity"
+        val refB = "https://models.example.org/severity-info-1.0.0.tm.jsonld#/properties/severity"
+
+        SharedTypeRegistry.registerRefTitle(refA, "Severity")
+        SharedTypeRegistry.registerRefTitle(refB, "Severity")
+        SharedTypeRegistry.markConflictingTitles()
+
+        assertTrue(SharedTypeRegistry.hasConflictingTitle(refA), "refA should be marked as conflicting")
+        assertTrue(SharedTypeRegistry.hasConflictingTitle(refB), "refB should be marked as conflicting")
+    }
+
+    @Test
+    fun `markConflictingTitles does not flag unique titles`() {
+        val refA = "https://models.example.org/day.tm.jsonld#/properties/day"
+        val refB = "https://models.example.org/transition.tm.jsonld#/properties/transition"
+
+        SharedTypeRegistry.registerRefTitle(refA, "Day")
+        SharedTypeRegistry.registerRefTitle(refB, "Transition")
+        SharedTypeRegistry.markConflictingTitles()
+
+        assertFalse(SharedTypeRegistry.hasConflictingTitle(refA))
+        assertFalse(SharedTypeRegistry.hasConflictingTitle(refB))
+    }
+
+    @Test
+    fun `markConflictingTitles uses asClassName normalization for conflict detection`() {
+        // "severity-info" and "Severity Info" both produce class name "SeverityInfo"
+        val refA = "https://models.example.org/a.tm.jsonld#/properties/a"
+        val refB = "https://models.example.org/b.tm.jsonld#/properties/b"
+
+        SharedTypeRegistry.registerRefTitle(refA, "severity-info")
+        SharedTypeRegistry.registerRefTitle(refB, "Severity Info")
+        SharedTypeRegistry.markConflictingTitles()
+
+        assertTrue(SharedTypeRegistry.hasConflictingTitle(refA), "hyphenated title should conflict")
+        assertTrue(SharedTypeRegistry.hasConflictingTitle(refB), "spaced title should conflict")
+    }
+
+    @Test
+    fun `clearRefMappings resets conflicting title state`() {
+        val refA = "https://models.example.org/a.tm.jsonld#/properties/a"
+        val refB = "https://models.example.org/b.tm.jsonld#/properties/b"
+
+        SharedTypeRegistry.registerRefTitle(refA, "Severity")
+        SharedTypeRegistry.registerRefTitle(refB, "Severity")
+        SharedTypeRegistry.markConflictingTitles()
+        assertTrue(SharedTypeRegistry.hasConflictingTitle(refA))
+
+        SharedTypeRegistry.clearRefMappings()
+        assertFalse(SharedTypeRegistry.hasConflictingTitle(refA), "should be cleared after clearRefMappings")
+    }
+
+    // --- Ref count and title-based naming tests ---
+
+    @Test
+    fun `ref count increments for each reference`() {
+        val refUrl = "https://models.example.org/day.tm.jsonld#/properties/day"
+
+        assertEquals(0, SharedTypeRegistry.getRefCount(refUrl))
+        SharedTypeRegistry.incrementRefCount(refUrl)
+        assertEquals(1, SharedTypeRegistry.getRefCount(refUrl))
+        SharedTypeRegistry.incrementRefCount(refUrl)
+        SharedTypeRegistry.incrementRefCount(refUrl)
+        assertEquals(3, SharedTypeRegistry.getRefCount(refUrl))
+    }
+
+    @Test
+    fun `ref title is stored and retrievable`() {
+        val refUrl = "https://models.example.org/day.tm.jsonld#/properties/day"
+
+        assertNull(SharedTypeRegistry.findRefTitle(refUrl))
+        SharedTypeRegistry.registerRefTitle(refUrl, "Day")
+        assertEquals("Day", SharedTypeRegistry.findRefTitle(refUrl))
+    }
+
+    @Test
+    fun `single-referenced tm-ref should not use title for naming`() {
+        // Simulates the naming decision: a ref with count=1 should keep property name
+        val refUrl = "https://models.example.org/severity-info.tm.jsonld#/properties/severity"
+        SharedTypeRegistry.registerRefTitle(refUrl, "Severity")
+        SharedTypeRegistry.incrementRefCount(refUrl)
+
+        // count == 1, so the generator should use the property name, not the title
+        assertTrue(SharedTypeRegistry.getRefCount(refUrl) <= 1)
+    }
+
+    @Test
+    fun `multi-referenced tm-ref with unique title should use title for naming`() {
+        // Simulates "Day" schema referenced 7 times by monday..sunday
+        val refUrl = "https://models.example.org/day.tm.jsonld#/properties/day"
+        SharedTypeRegistry.registerRefTitle(refUrl, "Day")
+        repeat(7) { SharedTypeRegistry.incrementRefCount(refUrl) }
+        SharedTypeRegistry.markConflictingTitles()
+
+        assertTrue(SharedTypeRegistry.getRefCount(refUrl) > 1, "should be multi-referenced")
+        assertFalse(SharedTypeRegistry.hasConflictingTitle(refUrl), "title should not be conflicting")
+        assertEquals("Day", SharedTypeRegistry.findRefTitle(refUrl))
+        // Generator should use "Day" as class name instead of "Monday"
+    }
+
+    @Test
+    fun `multi-referenced tm-ref with conflicting title should fall back to property name`() {
+        // Simulates "severity" and "severityInfo" both having title "Severity"
+        val refSeverity = "https://models.example.org/severity.tm.jsonld#/properties/severity"
+        val refSeverityInfo = "https://models.example.org/severity-info.tm.jsonld#/properties/severity"
+
+        SharedTypeRegistry.registerRefTitle(refSeverity, "Severity")
+        SharedTypeRegistry.registerRefTitle(refSeverityInfo, "Severity")
+        repeat(16) { SharedTypeRegistry.incrementRefCount(refSeverity) }
+        repeat(16) { SharedTypeRegistry.incrementRefCount(refSeverityInfo) }
+        SharedTypeRegistry.markConflictingTitles()
+
+        assertTrue(SharedTypeRegistry.getRefCount(refSeverity) > 1)
+        assertTrue(SharedTypeRegistry.getRefCount(refSeverityInfo) > 1)
+        assertTrue(SharedTypeRegistry.hasConflictingTitle(refSeverity), "should detect conflict")
+        assertTrue(SharedTypeRegistry.hasConflictingTitle(refSeverityInfo), "should detect conflict")
+        // Generator should fall back to property names "severity" and "severityInfo"
+    }
+
+    // --- normalizeSchema key-order independence ---
+
+    @Test
+    fun `findExistingClass matches schemas with different key order`() {
+        val schemaA = JsonObject.of("""{"type":"object","properties":{"name":{"type":"string"},"code":{"type":"integer"}},"required":["name","code"]}""")
+        val schemaB = JsonObject.of("""{"required":["name","code"],"type":"object","properties":{"code":{"type":"integer"},"name":{"type":"string"}}}""")
+        val className = ClassName("org.example", "MyClass")
+
+        SharedTypeRegistry.registerClass(schemaA, className)
+        val found = SharedTypeRegistry.findExistingClass(schemaB)
+
+        assertNotNull(found, "Should find class registered with differently-ordered keys")
+        assertEquals("MyClass", found.simpleName)
+    }
+
+    @Test
+    fun `findExistingClass matches schemas with different nested key order`() {
+        val schemaA = JsonObject.of("""{"type":"object","properties":{"inner":{"type":"object","properties":{"b":{"type":"string"},"a":{"type":"integer"}}}}}""")
+        val schemaB = JsonObject.of("""{"properties":{"inner":{"properties":{"a":{"type":"integer"},"b":{"type":"string"}},"type":"object"}},"type":"object"}""")
+        val className = ClassName("org.example", "Nested")
+
+        SharedTypeRegistry.registerClass(schemaA, className)
+        assertNotNull(SharedTypeRegistry.findExistingClass(schemaB), "Should match nested schemas with different key order")
+    }
+
+    @Test
+    fun `findExistingClass does NOT match structurally different schemas`() {
+        val schemaA = JsonObject.of("""{"type":"object","properties":{"name":{"type":"string"}}}""")
+        val schemaB = JsonObject.of("""{"type":"object","properties":{"name":{"type":"integer"}}}""")
+
+        SharedTypeRegistry.registerClass(schemaA, ClassName("org.example", "A"))
+        assertNull(SharedTypeRegistry.findExistingClass(schemaB), "Different schemas should not match")
+    }
+
+    @Test
+    fun `clearRefMappings also resets refCountRegistry`() {
+        val refUrl = "https://example.org/test.tm.jsonld#/properties/test"
+        SharedTypeRegistry.incrementRefCount(refUrl)
+        SharedTypeRegistry.incrementRefCount(refUrl)
+        assertEquals(2, SharedTypeRegistry.getRefCount(refUrl))
+
+        SharedTypeRegistry.clearRefMappings()
+        assertEquals(0, SharedTypeRegistry.getRefCount(refUrl), "refCount should be 0 after clearRefMappings")
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/ConfigurationMatrixTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/ConfigurationMatrixTest.kt
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.common
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.kotlin.generator.plugin.ThingModelGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.SharedTypeRegistry
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.EnumGenerationStrategy
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
+import org.eclipse.ditto.wot.kotlin.generator.plugin.property.TmRefScanner
+import org.eclipse.ditto.wot.model.ThingModel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests all configuration combinations to ensure the generator produces valid output
+ * regardless of the chosen naming strategy, enum strategy, and dedup setting.
+ *
+ * Uses a self-contained inline Thing Model with enough structure to exercise:
+ * - Class generation (nested objects)
+ * - Enum generation (string enums, object enums)
+ * - Deduplication (identical schemas across features)
+ * - Naming conflicts (same property name in different features)
+ *
+ * @since 1.1.0
+ */
+class ConfigurationMatrixTest {
+
+    companion object {
+        /**
+         * A Thing Model with two features sharing identical sub-schemas.
+         * - "sensor" and "actuator" both have a "status" object with {level, message}
+         * - "sensor" and "actuator" both have a "mode" string enum with {AUTO, MANUAL, OFF}
+         * - "sensor" has an extra "reading" property, "actuator" has "position"
+         */
+        private val TEST_MODEL_JSON = """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Config Matrix Test Device",
+              "version": { "model": "1.0.0" },
+              "properties": {
+                "sensor": {
+                  "title": "Sensor",
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "title": "Status",
+                      "type": "object",
+                      "properties": {
+                        "level": { "type": "string", "enum": ["OK", "WARNING", "ERROR"] },
+                        "message": { "type": "string" }
+                      },
+                      "additionalProperties": false,
+                      "required": ["level"]
+                    },
+                    "mode": { "type": "string", "enum": ["AUTO", "MANUAL", "OFF"] },
+                    "reading": { "type": "number" }
+                  }
+                },
+                "actuator": {
+                  "title": "Actuator",
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "title": "Status",
+                      "type": "object",
+                      "properties": {
+                        "level": { "type": "string", "enum": ["OK", "WARNING", "ERROR"] },
+                        "message": { "type": "string" }
+                      },
+                      "additionalProperties": false,
+                      "required": ["level"]
+                    },
+                    "mode": { "type": "string", "enum": ["AUTO", "MANUAL", "OFF"] },
+                    "position": { "type": "integer" }
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+    }
+
+    @BeforeTest
+    fun resetState() {
+        SharedTypeRegistry.clear()
+        SharedTypeRegistry.clearRefMappings()
+    }
+
+    @AfterTest
+    fun cleanupState() {
+        SharedTypeRegistry.clear()
+        SharedTypeRegistry.clearRefMappings()
+    }
+
+    // --- Configuration matrix: all 8 combinations generate without error ---
+
+    @Test
+    fun `ORIGINAL_THEN_COMPOUND + INLINE + dedup=true generates successfully`() {
+        assertGeneratesSuccessfully(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, dedup = true)
+    }
+
+    @Test
+    fun `ORIGINAL_THEN_COMPOUND + INLINE + dedup=false generates successfully`() {
+        assertGeneratesSuccessfully(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, dedup = false)
+    }
+
+    @Test
+    fun `COMPOUND_ALL + INLINE + dedup=true generates successfully`() {
+        assertGeneratesSuccessfully(ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.INLINE, dedup = true)
+    }
+
+    @Test
+    fun `COMPOUND_ALL + INLINE + dedup=false generates successfully`() {
+        assertGeneratesSuccessfully(ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.INLINE, dedup = false)
+    }
+
+    @Test
+    fun `ORIGINAL_THEN_COMPOUND + SEPARATE_CLASS + dedup=true generates successfully`() {
+        assertGeneratesSuccessfully(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.SEPARATE_CLASS, dedup = true)
+    }
+
+    @Test
+    fun `ORIGINAL_THEN_COMPOUND + SEPARATE_CLASS + dedup=false generates successfully`() {
+        assertGeneratesSuccessfully(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.SEPARATE_CLASS, dedup = false)
+    }
+
+    @Test
+    fun `COMPOUND_ALL + SEPARATE_CLASS + dedup=true generates successfully`() {
+        assertGeneratesSuccessfully(ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.SEPARATE_CLASS, dedup = true)
+    }
+
+    @Test
+    fun `COMPOUND_ALL + SEPARATE_CLASS + dedup=false generates successfully`() {
+        assertGeneratesSuccessfully(ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.SEPARATE_CLASS, dedup = false)
+    }
+
+    // --- Dedup behavior assertions ---
+
+    @Test
+    fun `dedup=true and dedup=false produce same or fewer files`() = runBlocking {
+        val dedupFiles = generateAndCountFiles(
+            ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, dedup = true
+        )
+        resetState()
+        val noDedupFiles = generateAndCountFiles(
+            ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, dedup = false
+        )
+
+        assertTrue(
+            dedupFiles <= noDedupFiles,
+            "Expected dedup=true ($dedupFiles files) to produce same or fewer files than dedup=false ($noDedupFiles files)"
+        )
+    }
+
+    @Test
+    fun `dedup=true with ORIGINAL naming produces exactly one Status class`() = runBlocking {
+        val outputDir = generateModel(
+            ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, dedup = true
+        )
+        try {
+            val statusFiles = findFiles(outputDir, "Status.kt")
+            assertEquals(
+                1, statusFiles.size,
+                "Expected 1 Status.kt (identical schema deduplicates). Found: $statusFiles"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `dedup=false with ORIGINAL naming still deduplicates same-package same-name schemas`() = runBlocking {
+        // Note: even without tm:ref dedup, same-package same-name schemas share a class
+        // because ClassRegistry detects the conflict and reuses the first one.
+        val outputDir = generateModel(
+            ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, dedup = false
+        )
+        try {
+            val statusFiles = findFiles(outputDir, "Status.kt")
+            // With flat model properties (not submodels), both land in the same package,
+            // so ClassRegistry dedup produces one file regardless.
+            assertTrue(
+                statusFiles.size >= 1,
+                "Expected at least 1 Status.kt. Found: $statusFiles"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `COMPOUND_ALL naming prefixes class names with parent`() = runBlocking {
+        val outputDir = generateModel(
+            ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.INLINE, dedup = false
+        )
+        try {
+            val allFiles = listAllKtFiles(outputDir)
+            // With COMPOUND_ALL, Status is prefixed: SensorStatus, ActuatorStatus
+            val sensorStatus = allFiles.any { it.contains("SensorStatus") }
+            val actuatorStatus = allFiles.any { it.contains("ActuatorStatus") }
+            assertTrue(sensorStatus, "Expected SensorStatus.kt with COMPOUND_ALL naming. Files: $allFiles")
+            assertTrue(actuatorStatus, "Expected ActuatorStatus.kt with COMPOUND_ALL naming. Files: $allFiles")
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    // --- Enum strategy assertions ---
+
+    @Test
+    fun `INLINE enums are nested inside parent class`() = runBlocking {
+        val outputDir = generateModel(
+            ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, dedup = false
+        )
+        try {
+            // With INLINE, Level enum should be inside Status.kt, not a separate file
+            val levelFiles = findFiles(outputDir, "Level.kt")
+            assertEquals(
+                0, levelFiles.size,
+                "Expected no separate Level.kt with INLINE enum strategy. Found: $levelFiles"
+            )
+
+            // But Status.kt should contain the Level enum
+            val statusFiles = findFiles(outputDir, "Status.kt")
+            assertTrue(statusFiles.isNotEmpty(), "Expected Status.kt to exist")
+            val statusContent = Files.readString(statusFiles.first())
+            assertTrue(
+                statusContent.contains("enum class Level") || statusContent.contains("sealed class Level"),
+                "Expected Level enum/sealed class inside Status.kt"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `SEPARATE_CLASS generates enum files for object-type enums`() = runBlocking {
+        // The SEPARATE_CLASS strategy generates standalone files for enums.
+        // String enums like "mode" may remain as inline Kotlin enum classes,
+        // but the enum strategy is applied. Verify generation succeeds.
+        val outputDir = generateModel(
+            ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.SEPARATE_CLASS, dedup = true
+        )
+        try {
+            val allFiles = listAllKtFiles(outputDir)
+            // With SEPARATE_CLASS, the Level enum inside Status should become a separate file
+            // (Status has a "level" string enum property)
+            val levelFiles = allFiles.filter { it.contains("Level") && it.endsWith(".kt") }
+            // Level might stay inline or become separate depending on how the schema is structured.
+            // The important thing is that generation succeeded without errors.
+            assertTrue(
+                allFiles.isNotEmpty(),
+                "Expected generated files with SEPARATE_CLASS strategy. Files: $allFiles"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    // --- tm:ref fingerprint dedup ---
+
+    @Test
+    fun `tm-ref fingerprint dedup works across features with different parent names`() = runBlocking {
+        // Pre-register a fingerprint simulating TmRefScanner
+        val statusSchema = JsonObject.of("""
+            {
+              "title": "Status",
+              "type": "object",
+              "properties": {
+                "level": { "type": "string", "enum": ["OK", "WARNING", "ERROR"] },
+                "message": { "type": "string" }
+              },
+              "additionalProperties": false,
+              "required": ["level"]
+            }
+        """.trimIndent())
+        val fingerprint = TmRefScanner.computeFingerprint(statusSchema)
+        val fakeRefUrl = "https://example.org/common/status-1.0.0.tm.jsonld#/properties/status"
+        SharedTypeRegistry.registerRefMapping(fingerprint, fakeRefUrl)
+
+        val outputDir = generateModel(
+            ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, dedup = true
+        )
+        try {
+            val statusFiles = findFiles(outputDir, "Status.kt")
+            assertEquals(
+                1, statusFiles.size,
+                "Expected 1 Status.kt via tm:ref fingerprint dedup. Found: $statusFiles"
+            )
+
+            // Verify it was registered in classRefRegistry
+            val registered = SharedTypeRegistry.findClassByRef(fakeRefUrl)
+            assertTrue(
+                registered != null && registered.simpleName == "Status",
+                "Expected Status registered against tm:ref URL. Got: $registered"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `stale tm-ref fingerprints do not leak across scan calls`() {
+        // Register a fingerprint
+        val fakeFingerprint = "{type:object,props:{stale:{type:string,},},}"
+        SharedTypeRegistry.registerRefMapping(fakeFingerprint, "https://old-model.org/stale.jsonld#/prop")
+
+        // Simulate a new scan (which clears ref mappings)
+        SharedTypeRegistry.clearRefMappings()
+
+        // The old fingerprint should be gone
+        val result = SharedTypeRegistry.findRefUrlByFingerprint(fakeFingerprint)
+        assertEquals(null, result, "Expected stale fingerprint to be cleared after new scan")
+    }
+
+    // --- Helpers ---
+
+    private fun assertGeneratesSuccessfully(
+        naming: ClassNamingStrategy,
+        enumStrategy: EnumGenerationStrategy,
+        dedup: Boolean
+    ) = runBlocking {
+        val outputDir = generateModel(naming, enumStrategy, dedup)
+        try {
+            val files = listAllKtFiles(outputDir)
+            assertTrue(
+                files.isNotEmpty(),
+                "Expected at least one generated file for config: naming=$naming, enum=$enumStrategy, dedup=$dedup"
+            )
+            // Basic sanity: should have the main model class
+            assertTrue(
+                files.any { it.contains("ConfigMatrixTestDevice") },
+                "Expected main model class. Files: ${files.take(10)}"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    private suspend fun generateModel(
+        naming: ClassNamingStrategy,
+        enumStrategy: EnumGenerationStrategy,
+        dedup: Boolean
+    ): Path {
+        val outputDir = Files.createTempDirectory("wot-kotlin-matrix-test")
+        val thingModel = ThingModel.fromJson(JsonObject.of(TEST_MODEL_JSON))
+        val outputPackage = "org.eclipse.ditto.wot.test.matrix"
+
+        ThingModelGenerator.generate(
+            thingModel,
+            GeneratorConfiguration(
+                thingModelUrl = "in-memory",
+                outputPackage = outputPackage,
+                outputDirectory = outputDir.toFile(),
+                deduplicateReferencedTypes = dedup,
+                classNamingStrategy = naming,
+                enumGenerationStrategy = enumStrategy
+            )
+        )
+        return outputDir
+    }
+
+    private suspend fun generateAndCountFiles(
+        naming: ClassNamingStrategy,
+        enumStrategy: EnumGenerationStrategy,
+        dedup: Boolean
+    ): Int {
+        val outputDir = generateModel(naming, enumStrategy, dedup)
+        try {
+            return listAllKtFiles(outputDir).size
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    private fun listAllKtFiles(dir: Path): List<String> {
+        return Files.walk(dir)
+            .filter { it.toString().endsWith(".kt") }
+            .map { dir.relativize(it).toString() }
+            .toList()
+    }
+
+    private fun findFiles(dir: Path, suffix: String): List<Path> {
+        return Files.walk(dir)
+            .filter { it.toString().endsWith(suffix) }
+            .toList()
+    }
+
+    private fun deleteRecursively(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DeduplicateReferencedTypesTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/DeduplicateReferencedTypesTest.kt
@@ -1,0 +1,576 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.common
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.kotlin.generator.plugin.ThingModelGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.SharedTypeRegistry
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
+import org.eclipse.ditto.wot.kotlin.generator.plugin.property.TmRefScanner
+import org.eclipse.ditto.wot.model.ThingModel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DeduplicateReferencedTypesTest {
+
+    @BeforeTest
+    fun resetState() {
+        SharedTypeRegistry.clear()
+        SharedTypeRegistry.clearRefMappings()
+    }
+
+    @AfterTest
+    fun cleanupState() {
+        SharedTypeRegistry.clear()
+        SharedTypeRegistry.clearRefMappings()
+    }
+
+    @Test
+    fun `dedup enabled - identical schemas with same name are generated once via schema JSON match`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-dedup-test")
+        try {
+            // Two top-level properties with identical "status" structure.
+            // Without tm:ref, the fallback dedup matches by schema JSON + same class name.
+            // Both properties have the same name "status" so the generated class name is the same.
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Dedup Test Device",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "sensorA": {
+                          "title": "Sensor A",
+                          "type": "object",
+                          "properties": {
+                            "value": { "type": "number" },
+                            "status": {
+                              "title": "Status",
+                              "type": "object",
+                              "properties": {
+                                "severity": { "type": "string" },
+                                "message": { "type": "string" }
+                              },
+                              "additionalProperties": false,
+                              "required": ["severity"]
+                            }
+                          }
+                        },
+                        "sensorB": {
+                          "title": "Sensor B",
+                          "type": "object",
+                          "properties": {
+                            "reading": { "type": "integer" },
+                            "status": {
+                              "title": "Status",
+                              "type": "object",
+                              "properties": {
+                                "severity": { "type": "string" },
+                                "message": { "type": "string" }
+                              },
+                              "additionalProperties": false,
+                              "required": ["severity"]
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.deduptest"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile(),
+                    deduplicateReferencedTypes = true,
+                    classNamingStrategy = org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy.ORIGINAL_THEN_COMPOUND
+                )
+            )
+
+            val allFiles = Files.walk(outputDir)
+                .filter { it.toString().endsWith(".kt") }
+                .map { outputDir.relativize(it).toString() }
+                .toList()
+
+            // "Status" class should exist once — both sensorA and sensorB have
+            // identical "status" schemas with the same name "Status" (ORIGINAL_THEN_COMPOUND
+            // uses the original title), so dedup matches by same name + same structure.
+            val statusFiles = allFiles.filter { it.endsWith("Status.kt") }
+            assertEquals(
+                1, statusFiles.size,
+                "Expected exactly one Status file with dedup enabled (same name + same structure). Found: $statusFiles"
+            )
+
+            // SensorB should reference SensorA's Status via import
+            val sensorBFile = allFiles.first { it.contains("SensorB.kt") }
+            val sensorBContent = Files.readString(outputDir.resolve(sensorBFile))
+            assertTrue(
+                sensorBContent.contains("Status"),
+                "SensorB should reference Status type"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `dedup enabled - different schemas with same name are NOT deduplicated`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-dedup-diff-test")
+        try {
+            // Two features with DIFFERENT "info" objects (different properties)
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Different Schema Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "featureA": {
+                          "title": "Feature A",
+                          "type": "object",
+                          "properties": {
+                            "info": {
+                              "title": "Info",
+                              "type": "object",
+                              "properties": {
+                                "level": { "type": "string" },
+                                "code": { "type": "integer" }
+                              }
+                            }
+                          }
+                        },
+                        "featureB": {
+                          "title": "Feature B",
+                          "type": "object",
+                          "properties": {
+                            "info": {
+                              "title": "Info",
+                              "type": "object",
+                              "properties": {
+                                "level": { "type": "string" },
+                                "description": { "type": "string" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.deduptestdiff"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile(),
+                    deduplicateReferencedTypes = true
+                )
+            )
+
+            val allFiles = Files.walk(outputDir)
+                .filter { it.toString().endsWith(".kt") }
+                .map { outputDir.relativize(it).toString() }
+                .toList()
+
+            // Both should exist since they have different structures
+            val infoFiles = allFiles.filter { it.contains("Info") && !it.contains("SeverityInfo") }
+            assertTrue(
+                infoFiles.size >= 2,
+                "Expected at least 2 Info files for different schemas. Found: $infoFiles"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `dedup disabled - all types generated in their own packages even if identical`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-no-dedup-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "No Dedup Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "featureA": {
+                          "title": "Feature A",
+                          "type": "object",
+                          "properties": {
+                            "info": {
+                              "title": "Info",
+                              "type": "object",
+                              "properties": {
+                                "level": { "type": "string" }
+                              }
+                            }
+                          }
+                        },
+                        "featureB": {
+                          "title": "Feature B",
+                          "type": "object",
+                          "properties": {
+                            "info": {
+                              "title": "Info",
+                              "type": "object",
+                              "properties": {
+                                "level": { "type": "string" }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.nodeduptest"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile(),
+                    deduplicateReferencedTypes = false
+                )
+            )
+
+            val allFiles = Files.walk(outputDir)
+                .filter { it.toString().endsWith(".kt") }
+                .map { outputDir.relativize(it).toString() }
+                .toList()
+
+            // With dedup disabled, both features get their own Info class
+            val infoFiles = allFiles.filter { it.endsWith("Info.kt") }
+            assertEquals(
+                2, infoFiles.size,
+                "Expected 2 Info files without dedup (one per feature). Found: $infoFiles"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `dedup enabled - tm-ref fingerprint path deduplicates across different parent names`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-tmref-dedup-test")
+        try {
+            // Two features with identical "details" schemas but different parent contexts.
+            // With ORIGINAL_THEN_COMPOUND, the class name stays "Details" for both.
+            // We simulate the tm:ref path by pre-registering a fingerprint in SharedTypeRegistry.
+            val detailsSchema = """
+                {
+                  "title": "Details",
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer" },
+                    "label": { "type": "string" }
+                  },
+                  "additionalProperties": false,
+                  "required": ["code", "label"]
+                }
+            """.trimIndent()
+
+            // Compute fingerprint and register it as if TmRefScanner found it
+            val fingerprint = TmRefScanner.computeFingerprint(
+                org.eclipse.ditto.json.JsonObject.of(detailsSchema)
+            )
+            val fakeRefUrl = "https://example.org/common/details-1.0.0.tm.jsonld#/properties/details"
+            SharedTypeRegistry.registerRefMapping(fingerprint, fakeRefUrl)
+
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "TmRef Dedup Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "sensorA": {
+                          "title": "Sensor A",
+                          "type": "object",
+                          "properties": {
+                            "details": $detailsSchema,
+                            "reading": { "type": "number" }
+                          }
+                        },
+                        "sensorB": {
+                          "title": "Sensor B",
+                          "type": "object",
+                          "properties": {
+                            "details": $detailsSchema,
+                            "value": { "type": "integer" }
+                          }
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.tmrefdeduptest"
+
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile(),
+                    deduplicateReferencedTypes = true,
+                    classNamingStrategy = org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy.ORIGINAL_THEN_COMPOUND
+                )
+            )
+
+            val allFiles = Files.walk(outputDir)
+                .filter { it.toString().endsWith(".kt") }
+                .map { outputDir.relativize(it).toString() }
+                .toList()
+
+            val detailsFiles = allFiles.filter { it.endsWith("Details.kt") }
+
+            // The tm:ref fingerprint match should cause dedup even though the schemas
+            // appear in different parent contexts. Only ONE Details.kt should exist.
+            assertEquals(
+                1, detailsFiles.size,
+                "Expected exactly one Details file via tm:ref fingerprint dedup. Found: $detailsFiles"
+            )
+
+            // Verify the tm:ref URL was registered in classRefRegistry
+            val registeredClass = SharedTypeRegistry.findClassByRef(fakeRefUrl)
+            assertTrue(
+                registeredClass != null,
+                "Expected the generated class to be registered against the tm:ref URL"
+            )
+            assertTrue(
+                registeredClass!!.simpleName == "Details",
+                "Expected registered class to be named 'Details', got: ${registeredClass.simpleName}"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `dedup preserves original JSON property name in startPath when class name differs`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-startpath-test")
+        try {
+            // Pre-register a multi-referenced tm:ref with title "Day" to trigger Option B naming.
+            // The property name "monday" should still be used for startPath().
+            val daySchema = """
+                {
+                  "title": "Day",
+                  "type": "object",
+                  "properties": {
+                    "transitions": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+            """.trimIndent()
+
+            val fingerprint = TmRefScanner.computeFingerprint(JsonObject.of(daySchema))
+            val fakeRefUrl = "https://example.org/day.tm.jsonld#/properties/day"
+            SharedTypeRegistry.registerRefMapping(fingerprint, fakeRefUrl)
+            SharedTypeRegistry.registerRefTitle(fakeRefUrl, "Day")
+            // Simulate multi-reference (7 days)
+            repeat(7) { SharedTypeRegistry.incrementRefCount(fakeRefUrl) }
+            SharedTypeRegistry.markConflictingTitles()
+
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of("""
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "StartPath Test",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "schedule": {
+                          "title": "Schedule",
+                          "type": "object",
+                          "properties": {
+                            "monday": $daySchema,
+                            "tuesday": $daySchema,
+                            "wednesday": $daySchema
+                          }
+                        }
+                      }
+                    }
+                """.trimIndent())
+            )
+
+            val outputPackage = "org.eclipse.ditto.wot.test.startpath"
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile(),
+                    deduplicateReferencedTypes = true,
+                    classNamingStrategy = org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy.ORIGINAL_THEN_COMPOUND
+                )
+            )
+
+            val allFiles = listAllKtFiles(outputDir)
+
+            // Class should be named "Day" (from tm:ref title), not "Monday"
+            val dayFiles = allFiles.filter { it.endsWith("Day.kt") }
+            assertTrue(dayFiles.isNotEmpty(), "Expected Day.kt to be generated. Files: $allFiles")
+
+            val mondayFiles = allFiles.filter { it.endsWith("Monday.kt") }
+            assertTrue(mondayFiles.isEmpty(), "Monday.kt should NOT exist — dedup should use 'Day' from tm:ref title. Files: $allFiles")
+
+            // startPath() should be "monday" (the original JSON property name), not "Day"
+            val dayContent = Files.readString(outputDir.resolve(dayFiles.first()))
+            assertTrue(
+                dayContent.contains(""""monday""""),
+                "Day.kt startPath should use original JSON property name 'monday', not class name. Content snippet: ${dayContent.take(500)}"
+            )
+
+            // Schedule should reference Day for all 3 properties
+            val scheduleFile = allFiles.first { it.contains("Schedule.kt") }
+            val scheduleContent = Files.readString(outputDir.resolve(scheduleFile))
+            assertTrue(scheduleContent.contains("Day?"), "Schedule should reference Day type for day properties")
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    @Test
+    fun `consecutive generate calls without manual clearing produce correct output`() = runBlocking {
+        val outputDirA = Files.createTempDirectory("wot-kotlin-consecutive-a")
+        val outputDirB = Files.createTempDirectory("wot-kotlin-consecutive-b")
+        val outputDirBalone = Files.createTempDirectory("wot-kotlin-consecutive-b-alone")
+        try {
+            val modelA = ThingModel.fromJson(JsonObject.of("""
+                {
+                  "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                  "@type": "tm:ThingModel",
+                  "title": "Device A",
+                  "version": { "model": "1.0.0" },
+                  "properties": {
+                    "status": {
+                      "title": "Status",
+                      "type": "object",
+                      "properties": {
+                        "level": { "type": "string", "enum": ["OK", "ERROR"] },
+                        "code": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+            """.trimIndent()))
+
+            val modelB = ThingModel.fromJson(JsonObject.of("""
+                {
+                  "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                  "@type": "tm:ThingModel",
+                  "title": "Device B",
+                  "version": { "model": "1.0.0" },
+                  "properties": {
+                    "status": {
+                      "title": "Status",
+                      "type": "object",
+                      "properties": {
+                        "mode": { "type": "string", "enum": ["FAST", "SLOW"] },
+                        "active": { "type": "boolean" }
+                      }
+                    }
+                  }
+                }
+            """.trimIndent()))
+
+            val configA = GeneratorConfiguration(
+                thingModelUrl = "in-memory-a",
+                outputPackage = "org.eclipse.ditto.wot.test.consecutive.a",
+                outputDirectory = outputDirA.toFile(),
+                classNamingStrategy = org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy.ORIGINAL_THEN_COMPOUND
+            )
+            val configB = GeneratorConfiguration(
+                thingModelUrl = "in-memory-b",
+                outputPackage = "org.eclipse.ditto.wot.test.consecutive.b",
+                outputDirectory = outputDirB.toFile(),
+                classNamingStrategy = org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy.ORIGINAL_THEN_COMPOUND
+            )
+            val configBalone = GeneratorConfiguration(
+                thingModelUrl = "in-memory-b",
+                outputPackage = "org.eclipse.ditto.wot.test.consecutive.b",
+                outputDirectory = outputDirBalone.toFile(),
+                classNamingStrategy = org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy.ORIGINAL_THEN_COMPOUND
+            )
+
+            // Generate A then B consecutively (without manual clearing)
+            ThingModelGenerator.generate(modelA, configA)
+            ThingModelGenerator.generate(modelB, configB)
+
+            // Generate B alone (fresh state)
+            SharedTypeRegistry.clear()
+            SharedTypeRegistry.clearRefMappings()
+            ThingModelGenerator.generate(modelB, configBalone)
+
+            // B consecutive output should match B alone output
+            val filesB = listAllKtFiles(outputDirB).sorted()
+            val filesBalone = listAllKtFiles(outputDirBalone).sorted()
+
+            assertEquals(filesBalone.map { it.substringAfterLast("/") }, filesB.map { it.substringAfterLast("/") },
+                "File names should be identical whether B is generated alone or after A")
+
+            // Verify B's Status has the right enum (FAST/SLOW not OK/ERROR from A)
+            val statusFileB = filesB.first { it.contains("Status.kt") }
+            val statusContent = Files.readString(outputDirB.resolve(statusFileB))
+            assertTrue(statusContent.contains("FAST"), "Model B Status should have FAST enum, not leaked from model A")
+            assertTrue(statusContent.contains("SLOW"), "Model B Status should have SLOW enum")
+        } finally {
+            deleteRecursively(outputDirA)
+            deleteRecursively(outputDirB)
+            deleteRecursively(outputDirBalone)
+        }
+    }
+
+    private fun listAllKtFiles(dir: Path): List<String> {
+        return Files.walk(dir)
+            .filter { it.toString().endsWith(".kt") }
+            .map { dir.relativize(it).toString() }
+            .toList()
+    }
+
+    private fun deleteRecursively(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/GeneratorIntegrationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/GeneratorIntegrationTest.kt
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.common
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.ditto.wot.kotlin.generator.plugin.GeneratorStarter
+import org.eclipse.ditto.wot.kotlin.generator.plugin.ThingModelGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.clazz.SharedTypeRegistry
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.ClassNamingStrategy
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.EnumGenerationStrategy
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Deep integration tests generating code from the Ditto floor-lamp example model.
+ *
+ * The floor-lamp model has:
+ * - 4 spot features (spot1, spot2, spot3, status-led) sharing the same submodel
+ * - Each spot has: Color (r,g,b,w properties), SwitchOnForDuration action, Toggle action
+ * - ConnectionStatus feature with readySince/readyUntil
+ * - PowerConsumptionAwareness feature with ReportPowerConsumption
+ * - SmokeDetection feature
+ * - Top-level actions: SwitchAllSpots, SwitchAllSpotsOnForDuration
+ * - Attributes with model info
+ *
+ * This model is public and domain-independent, and exercises:
+ * - Submodel resolution (spots share a common spot submodel)
+ * - Nested features with properties, actions
+ * - Class deduplication (Color, SwitchOnForDuration, Toggle across 4 spots)
+ * - tm:ref-based dedup (when enabled)
+ * - All naming strategies and enum strategies
+ *
+ * @since 1.1.0
+ */
+class GeneratorIntegrationTest {
+
+    companion object {
+        private const val FLOOR_LAMP_URL =
+            "https://eclipse-ditto.github.io/ditto-examples/wot/models/floor-lamp-1.0.0.tm.jsonld"
+
+        // Expected baseline counts (without dedup, ORIGINAL naming, INLINE enums)
+        // These are the reference numbers. If generation changes, update here.
+        private const val BASELINE_TOTAL_FILES = 36
+        private const val BASELINE_FEATURE_COUNT = 6 // spot1, spot2, spot3, status-led, connectionstatus, powerconsumptionawareness, smokedetection (but smokedetection has no properties file)
+        private const val BASELINE_COLOR_FILES = 4 // one per spot (spot1, spot2, spot3, status-led)
+        private const val BASELINE_TOGGLE_FILES = 4
+        private const val BASELINE_SWITCH_ON_FILES = 4
+    }
+
+    @BeforeTest
+    fun resetState() {
+        SharedTypeRegistry.clear()
+        SharedTypeRegistry.clearRefMappings()
+    }
+
+    // ===== Configuration matrix: all combos generate without error =====
+
+    @Test
+    fun `ORIGINAL + INLINE + dedup=false generates successfully`() {
+        val exitCode = runGenerator(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        assertEquals(0, exitCode)
+    }
+
+    @Test
+    fun `ORIGINAL + INLINE + dedup=true generates successfully`() {
+        val exitCode = runGenerator(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, true)
+        assertEquals(0, exitCode)
+    }
+
+    @Test
+    fun `COMPOUND_ALL + INLINE + dedup=false generates successfully`() {
+        val exitCode = runGenerator(ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.INLINE, false)
+        assertEquals(0, exitCode)
+    }
+
+    @Test
+    fun `COMPOUND_ALL + INLINE + dedup=true generates successfully`() {
+        val exitCode = runGenerator(ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.INLINE, true)
+        assertEquals(0, exitCode)
+    }
+
+    @Test
+    fun `ORIGINAL + SEPARATE_CLASS + dedup=true generates successfully`() {
+        val exitCode = runGenerator(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.SEPARATE_CLASS, true)
+        assertEquals(0, exitCode)
+    }
+
+    @Test
+    fun `COMPOUND_ALL + SEPARATE_CLASS + dedup=true generates successfully`() {
+        val exitCode = runGenerator(ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.SEPARATE_CLASS, true)
+        assertEquals(0, exitCode)
+    }
+
+    // ===== Baseline structure verification (ORIGINAL + INLINE + dedup=false) =====
+
+    @Test
+    fun `baseline produces expected file count`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        assertEquals(BASELINE_TOTAL_FILES, files.size, "Baseline file count mismatch. Files: $files")
+    }
+
+    @Test
+    fun `baseline contains main model class FloorLamp`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        assertTrue(files.any { it.endsWith("FloorLamp.kt") }, "Missing FloorLamp.kt")
+    }
+
+    @Test
+    fun `baseline contains Features and Attributes`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        assertTrue(files.any { it.endsWith("Features.kt") }, "Missing Features.kt")
+        assertTrue(files.any { it.endsWith("Attributes.kt") }, "Missing Attributes.kt")
+    }
+
+    @Test
+    fun `baseline contains all 4 spot feature classes`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        assertTrue(files.any { it.contains("spot1/Spot1.kt") }, "Missing Spot1.kt")
+        assertTrue(files.any { it.contains("spot2/Spot2.kt") }, "Missing Spot2.kt")
+        assertTrue(files.any { it.contains("spot3/Spot3.kt") }, "Missing Spot3.kt")
+        assertTrue(files.any { it.contains("status-led/StatusLed.kt") }, "Missing StatusLed.kt")
+    }
+
+    @Test
+    fun `baseline has Color class in each spot (no dedup)`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        val colorFiles = files.filter { it.endsWith("Color.kt") }
+        assertEquals(BASELINE_COLOR_FILES, colorFiles.size,
+            "Expected $BASELINE_COLOR_FILES Color.kt files without dedup. Found: $colorFiles")
+    }
+
+    @Test
+    fun `baseline has SwitchOnForDuration in each spot (no dedup)`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        val switchFiles = files.filter { it.endsWith("SwitchOnForDuration.kt") }
+        assertEquals(BASELINE_SWITCH_ON_FILES, switchFiles.size,
+            "Expected $BASELINE_SWITCH_ON_FILES SwitchOnForDuration.kt files. Found: $switchFiles")
+    }
+
+    @Test
+    fun `baseline has Toggle in each spot (no dedup)`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        val toggleFiles = files.filter { it.endsWith("Toggle.kt") }
+        assertEquals(BASELINE_TOGGLE_FILES, toggleFiles.size,
+            "Expected $BASELINE_TOGGLE_FILES Toggle.kt files. Found: $toggleFiles")
+    }
+
+    @Test
+    fun `baseline has top-level actions`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        assertTrue(files.any { it.endsWith("SwitchAllSpots.kt") }, "Missing SwitchAllSpots.kt")
+        assertTrue(files.any { it.endsWith("FloorLampAction.kt") }, "Missing FloorLampAction.kt")
+    }
+
+    @Test
+    fun `baseline has ConnectionStatus and PowerConsumptionAwareness features`() {
+        val files = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        assertTrue(files.any { it.contains("connectionstatus/ConnectionStatus.kt") }, "Missing ConnectionStatus.kt")
+        assertTrue(files.any { it.contains("powerconsumptionawareness/PowerConsumptionAwareness.kt") },
+            "Missing PowerConsumptionAwareness.kt")
+    }
+
+    // ===== Generated code content verification =====
+
+    @Test
+    fun `FloorLamp extends Thing with correct type parameters`() {
+        val dir = generateToDir(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        try {
+            val content = readFile(dir, "FloorLamp.kt")
+            assertTrue(content.contains("class FloorLamp"), "FloorLamp should be a class")
+            assertTrue(content.contains("Thing<Attributes, Features>"), "FloorLamp should extend Thing<Attributes, Features>")
+        } finally {
+            deleteRecursively(dir)
+        }
+    }
+
+    @Test
+    fun `Color has r, g, b, w properties`() {
+        val dir = generateToDir(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        try {
+            val content = readFile(dir, "spot1/properties/Color.kt")
+            assertTrue(content.contains("\"r\""), "Color should have 'r' property")
+            assertTrue(content.contains("\"g\""), "Color should have 'g' property")
+            assertTrue(content.contains("\"b\""), "Color should have 'b' property")
+            assertTrue(content.contains("\"w\""), "Color should have 'w' property")
+        } finally {
+            deleteRecursively(dir)
+        }
+    }
+
+    @Test
+    fun `Spot classes have HasPath companion with correct startPath`() {
+        val dir = generateToDir(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        try {
+            val spot1 = readFile(dir, "spot1/Spot1.kt")
+            assertTrue(spot1.contains("companion object : HasPath"), "Spot1 should have HasPath companion")
+            assertTrue(spot1.contains("startPath()"), "Spot1 companion should have startPath()")
+        } finally {
+            deleteRecursively(dir)
+        }
+    }
+
+    @Test
+    fun `DSL builder functions are generated`() {
+        val dir = generateToDir(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        try {
+            val content = readFile(dir, "FloorLamp.kt")
+            assertTrue(content.contains("fun attributes("), "FloorLamp should have attributes DSL builder")
+            assertTrue(content.contains("fun features("), "FloorLamp should have features DSL builder")
+        } finally {
+            deleteRecursively(dir)
+        }
+    }
+
+    // ===== Dedup behavior =====
+
+    @Test
+    fun `dedup=true produces fewer or equal files than dedup=false`() {
+        val noDedupFiles = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        resetState()
+        val dedupFiles = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, true)
+
+        assertTrue(dedupFiles.size <= noDedupFiles.size,
+            "dedup=true (${dedupFiles.size}) should produce <= files than dedup=false (${noDedupFiles.size})")
+    }
+
+    // ===== Determinism =====
+
+    @Test
+    fun `generation is deterministic - two runs produce identical file lists`() {
+        val run1 = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        resetState()
+        val run2 = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+
+        assertEquals(run1.sorted(), run2.sorted(), "Two runs should produce identical file lists")
+    }
+
+    @Test
+    fun `determinism - two runs produce identical file contents`() {
+        val dir1 = generateToDir(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        resetState()
+        val dir2 = generateToDir(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        try {
+            val files1 = listAllKtFiles(dir1).sorted()
+            val files2 = listAllKtFiles(dir2).sorted()
+            assertEquals(files1, files2, "File lists should match")
+
+            // Compare content of every file
+            for (relPath in files1) {
+                val content1 = Files.readString(dir1.resolve(relPath))
+                val content2 = Files.readString(dir2.resolve(relPath))
+                assertEquals(content1, content2, "Content mismatch in $relPath")
+            }
+        } finally {
+            deleteRecursively(dir1)
+            deleteRecursively(dir2)
+        }
+    }
+
+    // ===== Naming strategy comparison =====
+
+    @Test
+    fun `COMPOUND_ALL produces same number of features as ORIGINAL`() {
+        val originalFiles = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        resetState()
+        val compoundFiles = generateAndList(ClassNamingStrategy.COMPOUND_ALL, EnumGenerationStrategy.INLINE, false)
+
+        // File counts may differ slightly due to naming conflict resolution,
+        // but should be within 20% of each other
+        val ratio = compoundFiles.size.toDouble() / originalFiles.size.toDouble()
+        assertTrue(ratio in 0.8..1.2,
+            "COMPOUND_ALL (${compoundFiles.size}) and ORIGINAL (${originalFiles.size}) should have similar counts (ratio=$ratio)")
+    }
+
+    // ===== SEPARATE_CLASS vs INLINE =====
+
+    @Test
+    fun `SEPARATE_CLASS produces at least as many files as INLINE`() {
+        val inlineFiles = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.INLINE, false)
+        resetState()
+        val separateFiles = generateAndList(ClassNamingStrategy.ORIGINAL_THEN_COMPOUND, EnumGenerationStrategy.SEPARATE_CLASS, false)
+
+        assertTrue(separateFiles.size >= inlineFiles.size,
+            "SEPARATE_CLASS (${separateFiles.size}) should produce >= files than INLINE (${inlineFiles.size})")
+    }
+
+    // ===== Helpers =====
+
+    private fun runGenerator(naming: ClassNamingStrategy, enumStrategy: EnumGenerationStrategy, dedup: Boolean): Int {
+        val outputDir = Files.createTempDirectory("wot-integ-test")
+        try {
+            return GeneratorStarter.run(GeneratorConfiguration(
+                thingModelUrl = FLOOR_LAMP_URL,
+                outputPackage = "org.eclipse.ditto.wot.integ.test",
+                outputDirectory = outputDir.toFile(),
+                deduplicateReferencedTypes = dedup,
+                classNamingStrategy = naming,
+                enumGenerationStrategy = enumStrategy
+            ))
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    private fun generateAndList(naming: ClassNamingStrategy, enumStrategy: EnumGenerationStrategy, dedup: Boolean): List<String> {
+        val dir = generateToDir(naming, enumStrategy, dedup)
+        try {
+            return listAllKtFiles(dir)
+        } finally {
+            deleteRecursively(dir)
+        }
+    }
+
+    private fun generateToDir(naming: ClassNamingStrategy, enumStrategy: EnumGenerationStrategy, dedup: Boolean): Path {
+        val outputDir = Files.createTempDirectory("wot-integ-test")
+        val exitCode = GeneratorStarter.run(GeneratorConfiguration(
+            thingModelUrl = FLOOR_LAMP_URL,
+            outputPackage = "org.eclipse.ditto.wot.integ.test",
+            outputDirectory = outputDir.toFile(),
+            deduplicateReferencedTypes = dedup,
+            classNamingStrategy = naming,
+            enumGenerationStrategy = enumStrategy
+        ))
+        assertEquals(0, exitCode, "Generation failed")
+        return outputDir
+    }
+
+    private fun listAllKtFiles(dir: Path): List<String> {
+        return Files.walk(dir)
+            .filter { it.toString().endsWith(".kt") }
+            .map { dir.relativize(it).toString() }
+            .toList()
+    }
+
+    private fun readFile(dir: Path, suffix: String): String {
+        val file = Files.walk(dir)
+            .filter { it.toString().endsWith(suffix) }
+            .findFirst()
+            .orElseThrow { AssertionError("File ending with '$suffix' not found in $dir") }
+        return Files.readString(file)
+    }
+
+    private fun deleteRecursively(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/TmRefScannerTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/TmRefScannerTest.kt
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.property
+
+import org.eclipse.ditto.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Tests for [TmRefScanner.computeFingerprint] — the structural fingerprint that enables
+ * tm:ref-based deduplication even when the WoT library rewrites JSON metadata.
+ *
+ * @since 1.1.0
+ */
+class TmRefScannerTest {
+
+    @Test
+    fun `identical schemas produce identical fingerprints`() {
+        val schema1 = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "value": { "type": "integer" }
+              },
+              "required": ["name"]
+            }
+        """.trimIndent())
+
+        val schema2 = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "value": { "type": "integer" }
+              },
+              "required": ["name"]
+            }
+        """.trimIndent())
+
+        assertEquals(
+            TmRefScanner.computeFingerprint(schema1),
+            TmRefScanner.computeFingerprint(schema2)
+        )
+    }
+
+    @Test
+    fun `fingerprint ignores title and description`() {
+        val withMetadata = JsonObject.of("""
+            {
+              "title": "Severity Info",
+              "description": "Contains severity level and timestamp",
+              "type": "object",
+              "properties": {
+                "level": { "title": "Level", "type": "string" },
+                "activeSince": { "title": "Active Since", "description": "When it started", "type": "string" }
+              },
+              "required": ["level", "activeSince"]
+            }
+        """.trimIndent())
+
+        val withoutMetadata = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "level": { "type": "string" },
+                "activeSince": { "type": "string" }
+              },
+              "required": ["level", "activeSince"]
+            }
+        """.trimIndent())
+
+        assertEquals(
+            TmRefScanner.computeFingerprint(withMetadata),
+            TmRefScanner.computeFingerprint(withoutMetadata),
+            "Fingerprints should match regardless of title/description"
+        )
+    }
+
+    @Test
+    fun `fingerprint ignores readOnly, format, unit, and ditto-category`() {
+        val withAnnotations = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "timestamp": {
+                  "@type": "om2:Date",
+                  "type": "string",
+                  "readOnly": true,
+                  "format": "date-time",
+                  "unit": "xsd:dateTimeStamp"
+                }
+              }
+            }
+        """.trimIndent())
+
+        val bare = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "timestamp": { "type": "string" }
+              }
+            }
+        """.trimIndent())
+
+        assertEquals(
+            TmRefScanner.computeFingerprint(withAnnotations),
+            TmRefScanner.computeFingerprint(bare),
+            "Fingerprints should match regardless of readOnly/format/unit/@type"
+        )
+    }
+
+    @Test
+    fun `different property names produce different fingerprints`() {
+        val schema1 = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": { "name": { "type": "string" } }
+            }
+        """.trimIndent())
+
+        val schema2 = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": { "label": { "type": "string" } }
+            }
+        """.trimIndent())
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(schema1),
+            TmRefScanner.computeFingerprint(schema2)
+        )
+    }
+
+    @Test
+    fun `different types produce different fingerprints`() {
+        val stringType = JsonObject.of("""{ "type": "string" }""")
+        val integerType = JsonObject.of("""{ "type": "integer" }""")
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(stringType),
+            TmRefScanner.computeFingerprint(integerType)
+        )
+    }
+
+    @Test
+    fun `different required fields produce different fingerprints`() {
+        val schema1 = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "a": { "type": "string" },
+                "b": { "type": "string" }
+              },
+              "required": ["a"]
+            }
+        """.trimIndent())
+
+        val schema2 = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "a": { "type": "string" },
+                "b": { "type": "string" }
+              },
+              "required": ["a", "b"]
+            }
+        """.trimIndent())
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(schema1),
+            TmRefScanner.computeFingerprint(schema2)
+        )
+    }
+
+    @Test
+    fun `different enum values produce different fingerprints`() {
+        val schema1 = JsonObject.of("""
+            { "type": "string", "enum": ["OK", "WARNING"] }
+        """.trimIndent())
+
+        val schema2 = JsonObject.of("""
+            { "type": "string", "enum": ["OK", "WARNING", "ERROR"] }
+        """.trimIndent())
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(schema1),
+            TmRefScanner.computeFingerprint(schema2)
+        )
+    }
+
+    @Test
+    fun `different const values produce different fingerprints`() {
+        val schema1 = JsonObject.of("""
+            { "type": "string", "const": "temperature" }
+        """.trimIndent())
+
+        val schema2 = JsonObject.of("""
+            { "type": "string", "const": "humidity" }
+        """.trimIndent())
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(schema1),
+            TmRefScanner.computeFingerprint(schema2)
+        )
+    }
+
+    @Test
+    fun `property order does not affect fingerprint`() {
+        val schema1 = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "alpha": { "type": "string" },
+                "beta": { "type": "integer" }
+              }
+            }
+        """.trimIndent())
+
+        // Same properties, different JSON order
+        val schema2 = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "beta": { "type": "integer" },
+                "alpha": { "type": "string" }
+              }
+            }
+        """.trimIndent())
+
+        assertEquals(
+            TmRefScanner.computeFingerprint(schema1),
+            TmRefScanner.computeFingerprint(schema2),
+            "Fingerprints should be stable regardless of JSON property order"
+        )
+    }
+
+    @Test
+    fun `numeric constraints are included in fingerprint`() {
+        val withConstraints = JsonObject.of("""
+            { "type": "integer", "minimum": 0, "maximum": 60, "multipleOf": 10 }
+        """.trimIndent())
+
+        val withoutConstraints = JsonObject.of("""
+            { "type": "integer" }
+        """.trimIndent())
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(withConstraints),
+            TmRefScanner.computeFingerprint(withoutConstraints)
+        )
+    }
+
+    @Test
+    fun `additionalProperties value is included in fingerprint`() {
+        val withFalse = JsonObject.of("""
+            { "type": "object", "properties": { "x": { "type": "string" } }, "additionalProperties": false }
+        """.trimIndent())
+
+        val withoutIt = JsonObject.of("""
+            { "type": "object", "properties": { "x": { "type": "string" } } }
+        """.trimIndent())
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(withFalse),
+            TmRefScanner.computeFingerprint(withoutIt)
+        )
+    }
+
+    @Test
+    fun `nested objects are fingerprinted recursively`() {
+        val shallow = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "inner": { "type": "object", "properties": { "x": { "type": "string" } } }
+              }
+            }
+        """.trimIndent())
+
+        val deeperInner = JsonObject.of("""
+            {
+              "type": "object",
+              "properties": {
+                "inner": { "type": "object", "properties": { "x": { "type": "integer" } } }
+              }
+            }
+        """.trimIndent())
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(shallow),
+            TmRefScanner.computeFingerprint(deeperInner),
+            "Different nested property types should produce different fingerprints"
+        )
+    }
+
+    @Test
+    fun `oneOf composition is included in fingerprint`() {
+        val withOneOf = JsonObject.of("""
+            {
+              "oneOf": [
+                { "type": "string" },
+                { "type": "integer" }
+              ]
+            }
+        """.trimIndent())
+
+        val withoutOneOf = JsonObject.of("""
+            {
+              "oneOf": [
+                { "type": "string" }
+              ]
+            }
+        """.trimIndent())
+
+        val noComposition = JsonObject.of("{}")
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(withOneOf),
+            TmRefScanner.computeFingerprint(withoutOneOf),
+            "Different oneOf variants should produce different fingerprints"
+        )
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(withOneOf),
+            TmRefScanner.computeFingerprint(noComposition),
+            "Schema with oneOf should differ from schema without"
+        )
+    }
+
+    @Test
+    fun `allOf and anyOf composition are included in fingerprint`() {
+        val withAllOf = JsonObject.of("""
+            {
+              "allOf": [
+                { "type": "object", "properties": { "a": { "type": "string" } } },
+                { "type": "object", "properties": { "b": { "type": "integer" } } }
+              ]
+            }
+        """.trimIndent())
+
+        val withAnyOf = JsonObject.of("""
+            {
+              "anyOf": [
+                { "type": "object", "properties": { "a": { "type": "string" } } },
+                { "type": "object", "properties": { "b": { "type": "integer" } } }
+              ]
+            }
+        """.trimIndent())
+
+        assertNotEquals(
+            TmRefScanner.computeFingerprint(withAllOf),
+            TmRefScanner.computeFingerprint(withAnyOf),
+            "allOf and anyOf should produce different fingerprints"
+        )
+    }
+}


### PR DESCRIPTION
 **Summary**                                                                                                                                                                                 
                                                                                                                                                                                          
  - Add opt-in deduplicateReferencedTypes configuration parameter that collapses identical types shared via tm:ref into a single generated class, reducing duplicate code across features 
  - When multiple properties reference the same tm:ref, use the target schema's title as the class name instead of the first property name, with automatic fallback when titles conflict
  - Pre-scan Thing Model JSON before generation to discover tm:ref URLs and build fingerprint/title mappings, since the WoT library discards tm:ref metadata after resolution             
  - Fix stale registry state that caused already exists errors in multi-execution Maven builds (e.g., generating two models in the same reactor)                                          
  - Fix cross-package enum references when using SEPARATE_CLASS strategy with dedup enabled                                                                                               
  - Demote per-class/per-property log messages from info to debug to reduce build output noise                                                                                            
  - Fix minor code issues: unsafe .get() on Optional without null check, exposed internal mutable map, deprecated Kotlin API usage, duplicated KDoc blocks                                
  - Genericize domain-specific examples in code comments for open-source readiness                                                                                                        
  - Document the new feature in README including configuration, expected behavior, and interaction with existing strategies                                                               
                                                                                                                                                                                          
  **How deduplication works**                                                                                                                                                                 
                                                                                                                                                                                          
  1. Pre-scan: The generator scans the raw Thing Model JSON to discover all tm:ref URLs before the WoT library resolves them (which discards the reference metadata). It records a schema 
  fingerprint and title for each reference.                 
  2. Generate: During code generation, when a property's schema matches a previously generated type (by tm:ref URL or schema content), the existing class is reused via import instead of 
  generating a duplicate.                                                                                                                                                                 
  3. Naming: For multi-referenced types, the canonical title from the tm:ref target is used as the class name. Single-reference types keep the property name. Conflicting titles fall back
   to property names.                                                                                                                                                                     
                                                            
  **Backward compatibility**                                                                                                                                                                  
                                                            
  - deduplicateReferencedTypes defaults to false — existing behavior is completely unchanged                                                                                              
  - Regression tested against v1.1.0: byte-identical output for all existing configuration combinations