### PR TITLE
Add const value propagation for WoT-to-OpenAPI schema conversion

### DIFF
--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/Utils.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/Utils.kt
@@ -23,11 +23,15 @@ import org.eclipse.ditto.wot.model.DataSchemaType
 import org.eclipse.ditto.wot.model.MultipleDataSchema
 import org.eclipse.ditto.wot.model.Property
 import org.eclipse.ditto.wot.model.SingleDataSchema
+import org.eclipse.ditto.wot.model.SingleDataSchema.DataSchemaJsonFields
 import java.math.BigDecimal
 import kotlin.jvm.optionals.getOrNull
 import org.eclipse.ditto.wot.model.ArraySchema as WotArraySchema
+import org.eclipse.ditto.wot.model.IntegerSchema as WotIntegerSchema
+import org.eclipse.ditto.wot.model.NumberSchema as WotNumberSchema
 import org.eclipse.ditto.wot.model.ObjectSchema as WotObjectSchema
 import org.eclipse.ditto.wot.model.SingleDataSchema as WotSchema
+import org.eclipse.ditto.wot.model.StringSchema as WotStringSchema
 
 /**
  * Utility functions for Web of Things (WoT) to OpenAPI schema conversion.
@@ -224,33 +228,53 @@ object Utils {
         openAPI: OpenAPI? = null
     ): Schema<*> {
         schema.readOnly(wotSchema.isReadOnly).writeOnly(wotSchema.isWriteOnly)
+        val wotJson = wotSchema.toJson()
         when (schema) {
             is IntegerSchema, is NumberSchema -> {
-                wotSchema.toJson().getValue("minimum")?.getOrNull()?.let {
+                wotJson.getValue("minimum")?.getOrNull()?.let {
                     schema.minimum = when {
                         it.isNumber && schema is IntegerSchema -> BigDecimal(it.asInt())
                         it.isNumber && schema is NumberSchema -> BigDecimal(it.asDouble())
                         else -> null
                     }
                 }
-                wotSchema.toJson().getValue("maximum")?.getOrNull()?.let {
+                wotJson.getValue("maximum")?.getOrNull()?.let {
                     schema.maximum = when {
                         it.isNumber && schema is IntegerSchema -> BigDecimal(it.asInt())
                         it.isNumber && schema is NumberSchema -> BigDecimal(it.asDouble())
                         else -> null
                     }
                 }
+                wotSchema.const.getOrNull()?.let { constValue ->
+                    if (constValue.isNumber) {
+                        when (schema) {
+                            is IntegerSchema -> schema._const(constValue.asInt())
+                            is NumberSchema -> schema._const(BigDecimal.valueOf(constValue.asDouble()))
+                        }
+                    }
+                }
             }
 
             is StringSchema -> {
-                val enumValues = wotSchema.toJson().getValue("enum")?.getOrNull()?.asArray()
-                if (enumValues != null && enumValues.isEmpty.not()) {
+                wotSchema.enum.takeIf { it.isNotEmpty() }?.let { enumValues ->
                     schema.enum = enumValues.map { it.asString() }
                 }
-                schema.format = wotSchema.toJson().getValue("format")?.getOrNull()?.asString()
-                schema.pattern = wotSchema.toJson().getValue("pattern")?.getOrNull()?.asString()
+                schema.format = wotSchema.format.getOrNull()
+                schema.pattern = wotJson.getValue(WotStringSchema.JsonFields.PATTERN).getOrNull()
+                wotSchema.const.getOrNull()?.let { constValue ->
+                    if (constValue.isString) {
+                        schema._const(constValue.asString())
+                    }
+                }
             }
 
+            is BooleanSchema -> {
+                wotSchema.const.getOrNull()?.let { constValue ->
+                    if (constValue.isBoolean) {
+                        schema._const(constValue.asBoolean())
+                    }
+                }
+            }
         }
         return createComplexTypeStructureIfNeeded(wotSchema, schema, featureName, propertyOrAction, openAPI)
     }

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/Utils.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/Utils.kt
@@ -14,21 +14,28 @@ package org.eclipse.ditto.wot.openapi.generator
 
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.*
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.BooleanSchema
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.NumberSchema
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.StringSchema
 import org.eclipse.ditto.json.JsonObject
 import org.eclipse.ditto.json.JsonPointer
 import org.eclipse.ditto.json.JsonValue
-import org.eclipse.ditto.wot.model.Action
-import org.eclipse.ditto.wot.model.BaseLink
-import org.eclipse.ditto.wot.model.DataSchemaType
-import org.eclipse.ditto.wot.model.MultipleDataSchema
-import org.eclipse.ditto.wot.model.Property
+import org.eclipse.ditto.wot.model.*
 import org.eclipse.ditto.wot.model.SingleDataSchema
-import org.eclipse.ditto.wot.model.SingleDataSchema.DataSchemaJsonFields
 import java.math.BigDecimal
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.IllegalArgumentException
+import kotlin.String
+import kotlin.error
 import kotlin.jvm.optionals.getOrNull
+import kotlin.let
+import kotlin.takeIf
+import kotlin.to
 import org.eclipse.ditto.wot.model.ArraySchema as WotArraySchema
-import org.eclipse.ditto.wot.model.IntegerSchema as WotIntegerSchema
-import org.eclipse.ditto.wot.model.NumberSchema as WotNumberSchema
 import org.eclipse.ditto.wot.model.ObjectSchema as WotObjectSchema
 import org.eclipse.ditto.wot.model.SingleDataSchema as WotSchema
 import org.eclipse.ditto.wot.model.StringSchema as WotStringSchema
@@ -234,14 +241,14 @@ object Utils {
                 wotJson.getValue("minimum")?.getOrNull()?.let {
                     schema.minimum = when {
                         it.isNumber && schema is IntegerSchema -> BigDecimal(it.asInt())
-                        it.isNumber && schema is NumberSchema -> BigDecimal(it.asDouble())
+                        it.isNumber && schema is NumberSchema -> BigDecimal.valueOf(it.asDouble())
                         else -> null
                     }
                 }
                 wotJson.getValue("maximum")?.getOrNull()?.let {
                     schema.maximum = when {
                         it.isNumber && schema is IntegerSchema -> BigDecimal(it.asInt())
-                        it.isNumber && schema is NumberSchema -> BigDecimal(it.asDouble())
+                        it.isNumber && schema is NumberSchema -> BigDecimal.valueOf(it.asDouble())
                         else -> null
                     }
                 }

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/AttributeSchemaResolver.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/AttributeSchemaResolver.kt
@@ -16,10 +16,16 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.*
 import org.eclipse.ditto.json.JsonObject
 import org.eclipse.ditto.wot.model.DataSchemaType
+import org.eclipse.ditto.wot.model.SingleDataSchema.DataSchemaJsonFields
 import org.eclipse.ditto.wot.model.ThingModel
 import org.eclipse.ditto.wot.openapi.generator.Utils.extractDeprecationNotice
 import java.math.BigDecimal
 import kotlin.jvm.optionals.getOrNull
+import org.eclipse.ditto.wot.model.ArraySchema as WotArraySchema
+import org.eclipse.ditto.wot.model.IntegerSchema as WotIntegerSchema
+import org.eclipse.ditto.wot.model.NumberSchema as WotNumberSchema
+import org.eclipse.ditto.wot.model.ObjectSchema as WotObjectSchema
+import org.eclipse.ditto.wot.model.StringSchema as WotStringSchema
 
 /**
  * Resolver for WoT Thing attribute schemas to OpenAPI schemas.
@@ -68,7 +74,7 @@ object AttributeSchemaResolver {
      * @return The corresponding OpenAPI schema, or null if the type is not supported
      */
     fun getSchema(jsonObject: JsonObject): Schema<*>? {
-        return when (jsonObject.getValue("type")?.getOrNull()?.asString()?.uppercase()) {
+        return when (jsonObject.getValue(DataSchemaJsonFields.TYPE).getOrNull()?.uppercase()) {
             DataSchemaType.BOOLEAN.name -> injectSchemaOptions(jsonObject, BooleanSchema())
             DataSchemaType.INTEGER.name -> injectSchemaOptions(jsonObject, IntegerSchema())
             DataSchemaType.NUMBER.name -> injectSchemaOptions(jsonObject, NumberSchema())
@@ -81,33 +87,33 @@ object AttributeSchemaResolver {
 
     /**
      * Injects schema options and metadata into an OpenAPI schema.
-     * Handles readOnly, writeOnly, minimum, maximum, format, pattern, and enum values.
+     * Handles readOnly, writeOnly, minimum, maximum, format, pattern, enum, and const values.
      *
      * @param jsonObject The JSON object containing schema options
      * @param schema The OpenAPI schema to inject options into
      * @return The schema with injected options, or null if injection failed
      */
     fun injectSchemaOptions(jsonObject: JsonObject, schema: Schema<*>): Schema<*>? {
-        schema.readOnly = jsonObject.getValue("readOnly")?.getOrNull()?.asBoolean() ?: false
-        schema.writeOnly = jsonObject.getValue("writeOnly")?.getOrNull()?.asBoolean() ?: false
+        schema.readOnly = jsonObject.getValue(DataSchemaJsonFields.READ_ONLY).orElse(false)
+        schema.writeOnly = jsonObject.getValue(DataSchemaJsonFields.WRITE_ONLY).orElse(false)
         when (schema) {
             is IntegerSchema, is NumberSchema -> {
-                jsonObject.getValue("minimum")?.getOrNull()?.let {
-                    schema.minimum = when {
-                        it.isNumber && schema is IntegerSchema -> BigDecimal(it.asInt())
-                        it.isNumber && schema is NumberSchema -> BigDecimal(it.asDouble())
-                        else -> null
+                when (schema) {
+                    is IntegerSchema -> {
+                        jsonObject.getValue(WotIntegerSchema.JsonFields.MINIMUM).getOrNull()
+                            ?.let { schema.minimum = BigDecimal(it) }
+                        jsonObject.getValue(WotIntegerSchema.JsonFields.MAXIMUM).getOrNull()
+                            ?.let { schema.maximum = BigDecimal(it) }
                     }
-                }
-                jsonObject.getValue("maximum")?.getOrNull()?.let {
-                    schema.maximum = when {
-                        it.isNumber && schema is IntegerSchema -> BigDecimal(it.asInt())
-                        it.isNumber && schema is NumberSchema -> BigDecimal(it.asDouble())
-                        else -> null
+                    is NumberSchema -> {
+                        jsonObject.getValue(WotNumberSchema.JsonFields.MINIMUM).getOrNull()
+                            ?.let { schema.minimum = BigDecimal(it) }
+                        jsonObject.getValue(WotNumberSchema.JsonFields.MAXIMUM).getOrNull()
+                            ?.let { schema.maximum = BigDecimal(it) }
                     }
                 }
 
-                jsonObject.getValue("enum")?.getOrNull()?.asArray()?.let { enumValues ->
+                jsonObject.getValue(DataSchemaJsonFields.ENUM).getOrNull()?.let { enumValues ->
                     if (enumValues.isEmpty.not()) {
                         when (schema) {
                             is IntegerSchema -> schema.enum = enumValues.map { it.asInt() }
@@ -115,16 +121,38 @@ object AttributeSchemaResolver {
                         }
                     }
                 }
+
+                jsonObject.getValue(DataSchemaJsonFields.CONST).getOrNull()?.let { constValue ->
+                    if (constValue.isNumber) {
+                        when (schema) {
+                            is IntegerSchema -> schema._const(constValue.asInt())
+                            is NumberSchema -> schema._const(BigDecimal.valueOf(constValue.asDouble()))
+                        }
+                    }
+                }
             }
 
             is StringSchema -> {
-                schema.format = jsonObject.getValue("format")?.getOrNull()?.asString()
-                schema.pattern = jsonObject.getValue("pattern")?.getOrNull()?.asString()
+                schema.format = jsonObject.getValue(DataSchemaJsonFields.FORMAT).getOrNull()
+                schema.pattern = jsonObject.getValue(WotStringSchema.JsonFields.PATTERN).getOrNull()
 
-                // Handle enums for string schemas
-                jsonObject.getValue("enum")?.getOrNull()?.asArray()?.let { enumValues ->
+                jsonObject.getValue(DataSchemaJsonFields.ENUM).getOrNull()?.let { enumValues ->
                     if (enumValues.isEmpty.not()) {
                         schema.enum = enumValues.map { it.asString() }
+                    }
+                }
+
+                jsonObject.getValue(DataSchemaJsonFields.CONST).getOrNull()?.let { constValue ->
+                    if (constValue.isString) {
+                        schema._const(constValue.asString())
+                    }
+                }
+            }
+
+            is BooleanSchema -> {
+                jsonObject.getValue(DataSchemaJsonFields.CONST).getOrNull()?.let { constValue ->
+                    if (constValue.isBoolean) {
+                        schema._const(constValue.asBoolean())
                     }
                 }
             }
@@ -152,8 +180,8 @@ object AttributeSchemaResolver {
             val propertyObject = prop.value.asObject()
             val schema = getSchema(propertyObject) ?: return@forEach
             val deprecated = extractDeprecationNotice(propertyObject)?.deprecated == true
-            schema.title = propertyObject.getValue("title")?.getOrNull()?.asString()
-            schema.description = propertyObject.getValue("description")?.getOrNull()?.asString()
+            schema.title = propertyObject.getValue(DataSchemaJsonFields.TITLE).getOrNull()
+            schema.description = propertyObject.getValue(DataSchemaJsonFields.DESCRIPTION).getOrNull()
             if (deprecated) {
                 schema.deprecated(true)
             }
@@ -181,32 +209,34 @@ object AttributeSchemaResolver {
         when (schema) {
             is ObjectSchema -> {
                 val properties = createSubSchemaProperties(
-                    propertyObject.getValue("properties")?.getOrNull()?.asObject(),
+                    propertyObject.getValue(WotObjectSchema.JsonFields.PROPERTIES).getOrNull(),
                     openAPI,
                     fullPath
                 )
                 schema.properties(properties)
 
-                val requiredProps = propertyObject.getValue("required")?.getOrNull()?.asArray()?.map { it.asString() }
+                val requiredProps = propertyObject.getValue(WotObjectSchema.JsonFields.REQUIRED).getOrNull()
+                    ?.map { it.asString() }
                 if (!requiredProps.isNullOrEmpty()) {
                     schema.required(requiredProps)
                 }
             }
             is ArraySchema -> {
-                val itemsObject = propertyObject.getValue("items")?.getOrNull()?.asObject()
+                val itemsObject = propertyObject.getValue(WotArraySchema.JsonFields.ITEMS).getOrNull()
                 val itemSchema = getSchema(itemsObject ?: JsonObject.empty()) ?: schema as Schema<Any>
-                itemSchema.title = itemsObject?.getValue("title")?.getOrNull()?.asString()
-                itemSchema.description = itemsObject?.getValue("description")?.getOrNull()?.asString()
+                itemSchema.title = itemsObject?.getValue(DataSchemaJsonFields.TITLE)?.getOrNull()
+                itemSchema.description = itemsObject?.getValue(DataSchemaJsonFields.DESCRIPTION)?.getOrNull()
 
                 if (itemSchema is ObjectSchema) {
                     val properties = createSubSchemaProperties(
-                        itemsObject?.getValue("properties")?.getOrNull()?.asObject(),
+                        itemsObject?.getValue(WotObjectSchema.JsonFields.PROPERTIES)?.getOrNull(),
                         openAPI,
                         fullPath
                     )
                     itemSchema.properties(properties)
 
-                    val requiredProps = itemsObject?.getValue("required")?.getOrNull()?.asArray()?.map { it.asString() }
+                    val requiredProps = itemsObject?.getValue(WotObjectSchema.JsonFields.REQUIRED)?.getOrNull()
+                        ?.map { it.asString() }
                     if (!requiredProps.isNullOrEmpty()) {
                         itemSchema.required(requiredProps)
                     }
@@ -268,7 +298,11 @@ object AttributeSchemaResolver {
             schema1.description != schema2.description ||
             schema1.pattern != schema2.pattern ||
             schema1.readOnly != schema2.readOnly ||
-            schema1.writeOnly != schema2.writeOnly) {
+            schema1.writeOnly != schema2.writeOnly ||
+            schema1.const != schema2.const ||
+            schema1.enum != schema2.enum ||
+            schema1.minimum != schema2.minimum ||
+            schema1.maximum != schema2.maximum) {
             return false
         }
 

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/AttributeSchemaResolver.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/AttributeSchemaResolver.kt
@@ -107,9 +107,9 @@ object AttributeSchemaResolver {
                     }
                     is NumberSchema -> {
                         jsonObject.getValue(WotNumberSchema.JsonFields.MINIMUM).getOrNull()
-                            ?.let { schema.minimum = BigDecimal(it) }
+                            ?.let { schema.minimum = BigDecimal.valueOf(it) }
                         jsonObject.getValue(WotNumberSchema.JsonFields.MAXIMUM).getOrNull()
-                            ?.let { schema.maximum = BigDecimal(it) }
+                            ?.let { schema.maximum = BigDecimal.valueOf(it) }
                     }
                 }
 
@@ -117,7 +117,7 @@ object AttributeSchemaResolver {
                     if (enumValues.isEmpty.not()) {
                         when (schema) {
                             is IntegerSchema -> schema.enum = enumValues.map { it.asInt() }
-                            is NumberSchema -> schema.enum = enumValues.map { BigDecimal(it.asDouble()) }
+                            is NumberSchema -> schema.enum = enumValues.map { BigDecimal.valueOf(it.asDouble()) }
                         }
                     }
                 }

--- a/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/ConstPropagationTest.kt
+++ b/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/ConstPropagationTest.kt
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.openapi.generator
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Paths
+import io.swagger.v3.oas.models.media.BooleanSchema
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.NumberSchema
+import io.swagger.v3.oas.models.media.StringSchema
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.model.ThingModel
+import org.eclipse.ditto.wot.openapi.generator.thing.AttributeSchemaResolver
+import org.eclipse.ditto.wot.openapi.generator.thing.AttributesPathsGenerator
+import org.eclipse.ditto.wot.openapi.generator.features.FeaturesPathsGenerator
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ConstPropagationTest {
+
+    // --- Utils.convert() tests via asOpenApiSchema ---
+
+    @Test
+    fun `string const is propagated via Utils asOpenApiSchema`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "TestModel",
+              "properties": {
+                "deviceType": {
+                  "title": "Device Type",
+                  "type": "string",
+                  "const": "sensor"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("test", model, paths, api)
+
+        val propertyPath = paths["/{thingId}/features/test/properties/deviceType"]
+        assertNotNull(propertyPath)
+        val schema = propertyPath.get?.responses?.get("200")?.content?.get("application/json")?.schema
+        assertNotNull(schema)
+
+        val resolved = resolveSchema(schema, api)
+        assertEquals("sensor", resolved.const)
+        assertNull(resolved.enum)
+    }
+
+    @Test
+    fun `integer const is propagated via Utils asOpenApiSchema`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "TestModel",
+              "properties": {
+                "version": {
+                  "title": "Version",
+                  "type": "integer",
+                  "const": 42
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("test", model, paths, api)
+
+        val propertyPath = paths["/{thingId}/features/test/properties/version"]
+        assertNotNull(propertyPath)
+        val schema = propertyPath.get?.responses?.get("200")?.content?.get("application/json")?.schema
+        assertNotNull(schema)
+
+        val resolved = resolveSchema(schema, api)
+        assertEquals(42, resolved.const)
+        assertNull(resolved.enum)
+    }
+
+    @Test
+    fun `number const is propagated via Utils asOpenApiSchema`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "TestModel",
+              "properties": {
+                "fixedRate": {
+                  "title": "Fixed Rate",
+                  "type": "number",
+                  "const": 3.14
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("test", model, paths, api)
+
+        val propertyPath = paths["/{thingId}/features/test/properties/fixedRate"]
+        assertNotNull(propertyPath)
+        val schema = propertyPath.get?.responses?.get("200")?.content?.get("application/json")?.schema
+        assertNotNull(schema)
+
+        val resolved = resolveSchema(schema, api)
+        assertEquals(BigDecimal.valueOf(3.14), resolved.const)
+    }
+
+    @Test
+    fun `boolean const is propagated via Utils asOpenApiSchema`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "TestModel",
+              "properties": {
+                "alwaysOn": {
+                  "title": "Always On",
+                  "type": "boolean",
+                  "const": true
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("test", model, paths, api)
+
+        val propertyPath = paths["/{thingId}/features/test/properties/alwaysOn"]
+        assertNotNull(propertyPath)
+        val schema = propertyPath.get?.responses?.get("200")?.content?.get("application/json")?.schema
+        assertNotNull(schema)
+
+        val resolved = resolveSchema(schema, api)
+        assertEquals(true, resolved.const)
+    }
+
+    // --- AttributeSchemaResolver.injectSchemaOptions() tests ---
+
+    @Test
+    fun `injectSchemaOptions propagates string const`() {
+        val json = JsonObject.of("""{"type": "string", "const": "8"}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, StringSchema())
+
+        assertNotNull(schema)
+        assertEquals("8", schema.const)
+        assertNull(schema.enum)
+    }
+
+    @Test
+    fun `injectSchemaOptions propagates integer const`() {
+        val json = JsonObject.of("""{"type": "integer", "const": 42}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, IntegerSchema())
+
+        assertNotNull(schema)
+        assertEquals(42, schema.const)
+        assertNull(schema.enum)
+    }
+
+    @Test
+    fun `injectSchemaOptions propagates number const`() {
+        val json = JsonObject.of("""{"type": "number", "const": 9.81}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, NumberSchema())
+
+        assertNotNull(schema)
+        assertEquals(BigDecimal.valueOf(9.81), schema.const)
+        assertNull(schema.enum)
+    }
+
+    @Test
+    fun `injectSchemaOptions propagates boolean const`() {
+        val json = JsonObject.of("""{"type": "boolean", "const": false}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, BooleanSchema())
+
+        assertNotNull(schema)
+        assertEquals(false, schema.const)
+        assertNull(schema.enum)
+    }
+
+    @Test
+    fun `string const coexists with existing enum`() {
+        val json = JsonObject.of("""{"type": "string", "enum": ["a", "b"], "const": "a"}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, StringSchema())
+
+        assertNotNull(schema)
+        assertEquals("a", schema.const)
+        assertEquals(listOf("a", "b"), schema.enum)
+    }
+
+    @Test
+    fun `schema without const does not set const`() {
+        val json = JsonObject.of("""{"type": "string"}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, StringSchema())
+
+        assertNotNull(schema)
+        assertNull(schema.const)
+    }
+
+    @Test
+    fun `type-mismatched const is ignored for integer schema`() {
+        val json = JsonObject.of("""{"type": "integer", "const": "not_a_number"}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, IntegerSchema())
+
+        assertNotNull(schema)
+        assertNull(schema.const)
+    }
+
+    @Test
+    fun `type-mismatched const is ignored for string schema`() {
+        val json = JsonObject.of("""{"type": "string", "const": 42}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, StringSchema())
+
+        assertNotNull(schema)
+        assertNull(schema.const)
+    }
+
+    @Test
+    fun `type-mismatched const is ignored for boolean schema`() {
+        val json = JsonObject.of("""{"type": "boolean", "const": "true"}""")
+        val schema = AttributeSchemaResolver.injectSchemaOptions(json, BooleanSchema())
+
+        assertNotNull(schema)
+        assertNull(schema.const)
+    }
+
+    @Test
+    fun `const-only property with no type returns null from getSchema`() {
+        val json = JsonObject.of("""{"const": "sensor"}""")
+        val schema = AttributeSchemaResolver.getSchema(json)
+
+        assertNull(schema)
+    }
+
+    @Test
+    fun `boolean false const is propagated via Utils asOpenApiSchema`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "TestModel",
+              "properties": {
+                "disabled": {
+                  "title": "Disabled",
+                  "type": "boolean",
+                  "const": false
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("test", model, paths, api)
+
+        val propertyPath = paths["/{thingId}/features/test/properties/disabled"]
+        assertNotNull(propertyPath)
+        val schema = propertyPath.get?.responses?.get("200")?.content?.get("application/json")?.schema
+        assertNotNull(schema)
+
+        val resolved = resolveSchema(schema, api)
+        assertEquals(false, resolved.const)
+    }
+
+    @Test
+    fun `string const coexists with existing enum via Utils path`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "TestModel",
+              "properties": {
+                "status": {
+                  "title": "Status",
+                  "type": "string",
+                  "enum": ["active", "inactive"],
+                  "const": "active"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("test", model, paths, api)
+
+        val propertyPath = paths["/{thingId}/features/test/properties/status"]
+        assertNotNull(propertyPath)
+        val schema = propertyPath.get?.responses?.get("200")?.content?.get("application/json")?.schema
+        assertNotNull(schema)
+
+        val resolved = resolveSchema(schema, api)
+        assertEquals("active", resolved.const)
+        assertEquals(listOf("active", "inactive"), resolved.enum)
+    }
+
+    // --- Attribute-level end-to-end test ---
+
+    @Test
+    fun `thing attribute with string const is propagated end to end`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Thermostat",
+              "properties": {
+                "type": {
+                  "title": "Type",
+                  "type": "string",
+                  "const": "8"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val api = openApi()
+        val attributesSchema = AttributeSchemaResolver.provideAttributesSchema(model, api)
+        assertNotNull(attributesSchema)
+
+        val typeSchema = api.components.schemas["attribute_type"]
+        assertNotNull(typeSchema, "Expected attribute_type to be registered as component schema")
+        assertEquals("8", typeSchema.const)
+    }
+
+    // --- Schema equivalence tests ---
+
+    @Test
+    fun `schemas with different const values get unique refs`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "TestModel",
+              "properties": {
+                "deviceType": {
+                  "title": "Device Type",
+                  "type": "object",
+                  "properties": {
+                    "kind": { "type": "string", "const": "sensor" },
+                    "category": { "type": "string", "const": "temperature" }
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val api = openApi()
+        AttributeSchemaResolver.provideAttributesSchema(model, api)
+
+        val kindSchema = api.components.schemas["attribute_deviceType_kind"]
+        val categorySchema = api.components.schemas["attribute_deviceType_category"]
+        assertNotNull(kindSchema)
+        assertNotNull(categorySchema)
+        assertEquals("sensor", kindSchema.const)
+        assertEquals("temperature", categorySchema.const)
+    }
+
+    // --- Nested object with const properties ---
+
+    @Test
+    fun `nested object properties with const are propagated`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "TestModel",
+              "properties": {
+                "config": {
+                  "title": "Configuration",
+                  "type": "object",
+                  "properties": {
+                    "protocol": { "type": "string", "const": "MQTT" },
+                    "port": { "type": "integer", "const": 1883 }
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val api = openApi()
+        AttributeSchemaResolver.provideAttributesSchema(model, api)
+
+        val protocolSchema = api.components.schemas["attribute_config_protocol"]
+        assertNotNull(protocolSchema)
+        assertEquals("MQTT", protocolSchema.const)
+
+        val portSchema = api.components.schemas["attribute_config_port"]
+        assertNotNull(portSchema)
+        assertEquals(1883, portSchema.const)
+    }
+
+    // --- Real-world model tests (simulating resolved TMs) ---
+
+    @Test
+    fun `temperature sensor model - string const type and integer const sensorClass`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Temperature Sensor",
+              "properties": {
+                "type": {
+                  "title": "Type",
+                  "type": "string",
+                  "const": "8"
+                },
+                "sensorClass": {
+                  "title": "Sensor Class",
+                  "type": "integer",
+                  "const": 8
+                },
+                "manufacturer": {
+                  "title": "Manufacturer",
+                  "type": "string",
+                  "const": "ACME"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val api = openApi()
+        AttributeSchemaResolver.provideAttributesSchema(model, api)
+
+        val typeSchema = api.components.schemas["attribute_type"]
+        assertNotNull(typeSchema, "Expected attribute_type schema")
+        assertEquals("8", typeSchema.const)
+
+        val sensorClassSchema = api.components.schemas["attribute_sensorClass"]
+        assertNotNull(sensorClassSchema, "Expected attribute_sensorClass schema")
+        assertEquals(8, sensorClassSchema.const)
+
+        val manufacturerSchema = api.components.schemas["attribute_manufacturer"]
+        assertNotNull(manufacturerSchema, "Expected attribute_manufacturer schema")
+        assertEquals("ACME", manufacturerSchema.const)
+    }
+
+    @Test
+    fun `humidity sensor model - string const type and integer const sensorClass`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Humidity Sensor",
+              "properties": {
+                "type": {
+                  "title": "Type",
+                  "type": "string",
+                  "const": "26"
+                },
+                "sensorClass": {
+                  "title": "Sensor Class",
+                  "type": "integer",
+                  "const": 26
+                },
+                "manufacturer": {
+                  "title": "Manufacturer",
+                  "type": "string",
+                  "const": "ExampleCorp"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeaturesPathsGenerator.generateFeaturesPaths("humiditySensor", model, paths, api)
+
+        val typeSchema = resolveSchema(
+            paths["/{thingId}/features/humiditySensor/properties/type"]!!.get.responses["200"]!!.content["application/json"]!!.schema, api)
+        assertEquals("26", typeSchema.const)
+
+        val sensorClassSchema = resolveSchema(
+            paths["/{thingId}/features/humiditySensor/properties/sensorClass"]!!.get.responses["200"]!!.content["application/json"]!!.schema, api)
+        assertEquals(26, sensorClassSchema.const)
+
+        val mfgSchema = resolveSchema(
+            paths["/{thingId}/features/humiditySensor/properties/manufacturer"]!!.get.responses["200"]!!.content["application/json"]!!.schema, api)
+        assertEquals("ExampleCorp", mfgSchema.const)
+    }
+
+    // --- Helper functions ---
+
+    private fun resolveSchema(schema: io.swagger.v3.oas.models.media.Schema<*>, api: OpenAPI): io.swagger.v3.oas.models.media.Schema<*> {
+        val ref = schema.`$ref`
+        if (ref != null) {
+            val schemaName = ref.removePrefix("#/components/schemas/")
+            return api.components?.schemas?.get(schemaName) ?: schema
+        }
+        return schema
+    }
+
+    private fun thingModelFromJson(json: String): ThingModel =
+        ThingModel.fromJson(JsonObject.of(json))
+
+    private fun openApi() = OpenAPI().components(Components().schemas(mutableMapOf()))
+}

--- a/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/ConstPropagationYamlOutputTest.kt
+++ b/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/ConstPropagationYamlOutputTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.openapi.generator
+
+import io.swagger.v3.core.util.ObjectMapperFactory
+import io.swagger.v3.core.util.Yaml31
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Paths
+import io.swagger.v3.oas.models.SpecVersion
+import io.swagger.v3.oas.models.info.Info
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.model.ThingModel
+import org.eclipse.ditto.wot.openapi.generator.features.FeaturesPathsGenerator
+import org.eclipse.ditto.wot.openapi.generator.thing.AttributeSchemaResolver
+import org.eclipse.ditto.wot.openapi.generator.thing.AttributesPathsGenerator
+import java.io.StringWriter
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+class ConstPropagationYamlOutputTest {
+
+    @Test
+    fun `generate YAML for temperature sensor model and verify const in output`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Temperature Sensor",
+              "description": "A generic temperature sensor device.",
+              "properties": {
+                "type": {
+                  "title": "Type",
+                  "type": "string",
+                  "const": "8"
+                },
+                "sensorClass": {
+                  "title": "Sensor Class",
+                  "type": "integer",
+                  "const": 8
+                },
+                "manufacturer": {
+                  "title": "Manufacturer",
+                  "type": "string",
+                  "const": "ACME"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val yaml = generateYaml(model, "temperatureSensor")
+
+        assertContains(yaml, "const: \"8\"")
+        assertContains(yaml, "const: 8")
+        assertContains(yaml, "const: ACME")
+
+        // Verify no redundant enum fallback is emitted alongside const
+        val constSchemaBlocks = yaml.split("const:").drop(1)
+        constSchemaBlocks.forEach { block ->
+            val nextLines = block.lines().take(3).joinToString("\n")
+            assertFalse(nextLines.contains("enum:"), "enum should not appear alongside const in YAML output")
+        }
+    }
+
+    @Test
+    fun `generate YAML for humidity sensor model and verify const in output`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Humidity Sensor",
+              "description": "A generic humidity sensor device.",
+              "properties": {
+                "type": {
+                  "title": "Type",
+                  "type": "string",
+                  "const": "26"
+                },
+                "sensorClass": {
+                  "title": "Sensor Class",
+                  "type": "integer",
+                  "const": 26
+                },
+                "manufacturer": {
+                  "title": "Manufacturer",
+                  "type": "string",
+                  "const": "ExampleCorp"
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val yaml = generateYaml(model, "humiditySensor")
+
+        assertContains(yaml, "const: \"26\"")
+        assertContains(yaml, "const: 26")
+        assertContains(yaml, "const: ExampleCorp")
+
+        // Verify no redundant enum fallback is emitted alongside const
+        val constSchemaBlocks = yaml.split("const:").drop(1)
+        constSchemaBlocks.forEach { block ->
+            val nextLines = block.lines().take(3).joinToString("\n")
+            assertFalse(nextLines.contains("enum:"), "enum should not appear alongside const in YAML output")
+        }
+    }
+
+    private fun generateYaml(model: ThingModel, featureName: String): String {
+        val openAPI = OpenAPI(SpecVersion.V31)
+            .openapi("3.1.0")
+            .info(
+                Info()
+                    .title(model.title.get().toString())
+                    .description(model.description.orElse(null)?.toString())
+            )
+        openAPI.components(Components().schemas(mutableMapOf()))
+
+        val paths = Paths()
+
+        // Generate thing attribute paths
+        AttributesPathsGenerator.generateThingAttributesPaths(model, paths, openAPI)
+        openAPI.schema("attributes", AttributeSchemaResolver.provideAttributesSchema(model, openAPI))
+
+        // Generate feature paths
+        FeaturesPathsGenerator.generateFeaturesPaths(featureName, model, paths, openAPI)
+
+        openAPI.paths(paths)
+
+        val writer = StringWriter()
+        val jsonGenerator = ObjectMapperFactory.createYaml31().createGenerator(writer)
+        Yaml31.mapper().writeValue(jsonGenerator, openAPI)
+        return writer.toString()
+    }
+
+    private fun thingModelFromJson(json: String): ThingModel =
+        ThingModel.fromJson(JsonObject.of(json))
+}


### PR DESCRIPTION
## Summary  
The WoT-to-OpenAPI generator now propagates `const` values from WoT Thing Model                                                                                                         
  schemas into the generated OpenAPI 3.1.0 specification.
                                                                                                                                                                                          
  Previously, a WoT property defined with a fixed value (e.g. `"const": "8"`) appeared                                                                                                    
  in the OpenAPI output only as its base type, losing the contract constraint. Now, the
  generator emits the `const` keyword in the OpenAPI schema, preserving the full WoT contract.                                                                                            
                                                                                                                                                                                          
  Supported for all primitive schema types: `string`, `integer`, `number`, `boolean`.                                                                                                     
                                                                                                                                                                                          
  ### Changes                                                                                                                                                                             
                                                                                                                                                                                        
  - **Utils.kt**: Added `const` propagation in `convert()` using the typed                                                                                                                
    `SingleDataSchema.getConst()` API with type guards (`isNumber`, `isString`, `isBoolean`)
  - **AttributeSchemaResolver.kt**: Added `const` propagation in `injectSchemaOptions()`,                                                                                                 
    refactored raw string literals to use `DataSchemaJsonFields` and WoT model `JsonFields`                                                                                               
    constants for type-safe field access, updated `schemasAreEquivalent()` to compare                                                                                                     
    `const` and `enum` values to prevent incorrect schema deduplication                                                                                                                   
  - **ConstPropagationTest.kt**: 21 tests covering all primitive types via both code paths                                                                                                
    (Utils and AttributeSchemaResolver), nested objects, schema equivalence, type-mismatch                                                                                                
    guards, and end-to-end integration with real-world model patterns                                                                                                                     
  - **ConstPropagationYamlOutputTest.kt**: YAML output verification including assertion                                                                                                   
    that no redundant `enum` is emitted alongside `const`                                   