### PR TITLE
Emit WoT metadata as KDoc on generated Kotlin code

### DIFF
--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/ThingModelGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/ThingModelGenerator.kt
@@ -109,9 +109,11 @@ object ThingModelGenerator {
         logger.debug("Generate DSL: ${config.generateDsl}")
         logger.debug("Generate Enums: ${config.generateEnums}")
         logger.debug("Generate Interfaces: ${config.generateInterfaces}")
+        logger.debug("Generate KDoc: ${config.generateKdoc}")
 
         classGenerator.setOutputDir(config.outputDirectory.path)
         classGenerator.setEnumGenerationStrategy(config)
+        KdocGenerator.configure(config.generateKdoc)
 
         // Clear all registries at the start of each generation run to prevent stale state
         // from a previous model leaking into the current one in multi-execution builds.
@@ -143,7 +145,11 @@ object ThingModelGenerator {
         classGenerator.generateThingActions(config.outputPackage, thingModel)
         classGenerator.generateFeaturesClass(config.outputPackage, links)
 
-        val thingModelClass = TypeSpec.classBuilder(modelName)
+        val thingModelKdoc = KdocGenerator.forText(
+            thingModel.title.getOrNull()?.toString(),
+            thingModel.description.getOrNull()?.toString()
+        )
+        val thingModelClassBuilder = TypeSpec.classBuilder(modelName)
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
             .addAnnotation(buildJsonIncludeAnnotationSpec())
             .addAnnotation(buildJsonIgnoreAnnotationSpec())
@@ -166,10 +172,11 @@ object ThingModelGenerator {
                     "${config.outputPackage}.features"
                 )
             )
-            .build()
+        thingModelKdoc?.let { thingModelClassBuilder.addKdoc("%L", it) }
+        val thingModelClass = thingModelClassBuilder.build()
 
         val file = FileSpec.builder(config.outputPackage, modelName).addType(thingModelClass)
-            .addFunction(generateModelEntryDslFunSpec(modelName, config.outputPackage))
+            .addFunction(generateModelEntryDslFunSpec(modelName, config.outputPackage, thingModelKdoc))
             .build()
         file.writeTo(Path(config.outputDirectory.path))
     }
@@ -195,11 +202,16 @@ object ThingModelGenerator {
      * @param package The package name where the DSL function will be generated
      * @return A [FunSpec] representing the DSL function
      */
-    private fun generateModelEntryDslFunSpec(modelName: String, `package`: String): FunSpec {
+    private fun generateModelEntryDslFunSpec(
+        modelName: String,
+        `package`: String,
+        kdoc: String? = null
+    ): FunSpec {
         val modelClassName = ClassName(asPackageName(`package`), modelName)
         val propertyName = asPropertyName(modelName)
         val funSpecBuilder = FunSpec.builder(propertyName)
             .returns(modelClassName)
+        kdoc?.let { funSpecBuilder.addKdoc("%L", it) }
 
         // Add suspend modifier if configured
         if (classGenerator.getConfig()?.generateSuspendDsl == true) {

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/WotKotlinCodegenMojo.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/WotKotlinCodegenMojo.kt
@@ -90,6 +90,10 @@ class WotKotlinCodegenMojo: AbstractMojo() {
     @Parameter(property = "generateInterfaces", defaultValue = "true")
     var generateInterfaces: Boolean = true
 
+    /** Whether to render WoT metadata (title, description, unit, constraints, ...) as KDoc on the generated code */
+    @Parameter(property = "generateKdoc", defaultValue = "true")
+    var generateKdoc: Boolean = true
+
     /**
      * When true, generates a self-contained submodel package: feature classes, a single-feature
      * Features container, and a device-agnostic Thing — without attributes or multi-device wrappers.
@@ -216,6 +220,7 @@ class WotKotlinCodegenMojo: AbstractMojo() {
             generateSuspendDsl = generateSuspendDsl,
             generateEnums = generateEnums,
             generateInterfaces = generateInterfaces,
+            generateKdoc = generateKdoc,
             submodelOnly = submodelOnly,
             featureName = featureName,
             deduplicateReferencedTypes = deduplicateReferencedTypes

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/ClassGenerator.kt
@@ -633,6 +633,10 @@ object ClassGenerator {
     ): Triple<PropertySpec, String, DeprecationNotice?> {
         val propertyName = asPropertyName(originalFeatureName)
         val featurePackage = "$featuresPackageName.${asPackageName(originalFeatureName)}"
+        val featureKdoc = KdocGenerator.forText(
+            featureModel.title.getOrNull()?.toString(),
+            featureModel.description.getOrNull()?.toString()
+        )
         val linkProperties = propertyResolver.resolveProperties(
             featureModel.properties.getOrNull(), "$featurePackage.properties",
             PropertyRole.nextLevel(PropertyRole.FEATURE), propertyName
@@ -645,12 +649,14 @@ object ClassGenerator {
         }
         generateFeatureClassFromProperties(
             originalFeatureName, asClassName(propertyName), featurePackage,
-            featureModel.properties.getOrNull(), featureModel.actions.getOrNull(), submodelDeprecationNotice
+            featureModel.properties.getOrNull(), featureModel.actions.getOrNull(), submodelDeprecationNotice, featureKdoc
         )
         return Triple(
             PropertySpec.builder(
                 propertyName, ClassName(featurePackage, asClassName(propertyName)).copy(nullable = true)
-            ).mutable(true).initializer("null").build(),
+            ).mutable(true).initializer("null")
+                .apply { featureKdoc?.let { addKdoc("%L", it) } }
+                .build(),
             originalFeatureName,
             submodelDeprecationNotice
         )
@@ -776,6 +782,7 @@ object ClassGenerator {
         val typeSpecBuilder = TypeSpec.classBuilder(className)
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
             .addAnnotation(buildJsonIncludeAnnotationSpec())
+        KdocGenerator.forSchema(objectSchema)?.let { typeSpecBuilder.addKdoc("%L", it) }
 
         superClass?.let {
             typeSpecBuilder.superclass(it)
@@ -971,7 +978,10 @@ object ClassGenerator {
                                                   packageName: String, originalName: String? = null) {
         val featureDslFunsSpecs = properties.map {
             val propClassName = it.first.type as ClassName
-            dslGenerator.generateFeatureDslFunSpec(propClassName.simpleName, propClassName.packageName, deprecationNotice = it.third)
+            val accessorKdoc = it.first.kdoc.takeUnless { kb -> kb.isEmpty() }?.toString()
+            dslGenerator.generateFeatureDslFunSpec(
+                propClassName.simpleName, propClassName.packageName, deprecationNotice = it.third, kdoc = accessorKdoc
+            )
         }
 
         val typeSpecBuilder = TypeSpec.classBuilder(className)
@@ -1032,7 +1042,8 @@ object ClassGenerator {
         packageName: String,
         wotProperties: Properties?,
         wotActions: Actions?,
-        submodelDeprecationNotice: DeprecationNotice? = null
+        submodelDeprecationNotice: DeprecationNotice? = null,
+        featureKdoc: String? = null
     ) {
         val featurePropertiesClassName = featureClassName + "Properties"
         val featureClass = ClassName(packageName, featureClassName)
@@ -1065,6 +1076,7 @@ object ClassGenerator {
             .addSuperclassConstructorParameter("FEATURE_NAME")
             .addType(companionObject)
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
+        featureKdoc?.let { typeSpecBuilder.addKdoc("%L", it) }
 
         if (submodelDeprecationNotice?.deprecated == true) {
             typeSpecBuilder.addAnnotation(buildDeprecatedAnnotationSpec(submodelDeprecationNotice))
@@ -1084,10 +1096,18 @@ object ClassGenerator {
             typeSpecBuilder.build(),
             featureClassName,
             packageName,
-            listOf(dslGenerator.generateFeatureDslFunSpec(featureClassName, packageName, true)),
+            listOf(dslGenerator.generateFeatureDslFunSpec(featureClassName, packageName, true, kdoc = featureKdoc)),
             originalName = originalFeatureName
         )
     }
+
+    /**
+     * Derives the enum type name for a primitive action input/output schema that declares an `enum`.
+     * Prefers the schema's title (so a "Mode" input reuses the same `Mode` enum as the property), falling
+     * back to the provided name when no title is present.
+     */
+    private fun actionEnumName(schema: SingleDataSchema, fallback: String): String =
+        schema.title.getOrNull()?.toString()?.takeIf { it.isNotBlank() } ?: fallback
 
     private fun generateActionInterface(
         featureClassName: String,
@@ -1099,8 +1119,18 @@ object ClassGenerator {
             val actionClassAlias = asClassName(action.actionName)
             val interfaceSpec = TypeSpec.interfaceBuilder(actionClassAlias)
                 .addSuperinterface(actionMarkerInterfaceClassName)
+            val inputSchema = action.input.getOrNull()
+            var inputIsEnum = false
             val inputType = action.input.getOrNull()?.let {
                 when {
+                    it.type.isPresent && isPrimitive(it.type.getOrNull()) && it.enum?.isNotEmpty() == true -> {
+                        inputIsEnum = true
+                        resolveActionEnumType(
+                            it, actionEnumName(it, "${actionClassAlias}Input"), it.enum!!,
+                            packageName, actionClassAlias, interfaceSpec
+                        )
+                    }
+
                     it.type.isPresent && isPrimitive(it.type.getOrNull()) -> {
                         asPrimitiveClassName(it)
                     }
@@ -1127,6 +1157,13 @@ object ClassGenerator {
 
             val outputType = action.output.getOrNull()?.let {
                 when {
+                    it.type.isPresent && isPrimitive(it.type.getOrNull()) && it.enum?.isNotEmpty() == true -> {
+                        resolveActionEnumType(
+                            it, actionEnumName(it, "${actionClassAlias}Output"), it.enum!!,
+                            packageName, actionClassAlias, interfaceSpec
+                        )
+                    }
+
                     it.type.isPresent && isPrimitive(it.type.getOrNull()) -> {
                         asPrimitiveClassName(it)
                     }
@@ -1153,8 +1190,16 @@ object ClassGenerator {
                 .addModifiers(KModifier.ABSTRACT)
                 .addModifiers(KModifier.SUSPEND)
 
+            KdocGenerator.forText(
+                action.title.getOrNull()?.toString(),
+                action.description.getOrNull()?.toString()
+            )?.let { functionBuilder.addKdoc("%L", it) }
+
             inputType?.let {
-                functionBuilder.addParameter("input", it)
+                val inputParam = ParameterSpec.builder("input", it)
+                KdocGenerator.forSchema(inputSchema, includeAllowedValues = !inputIsEnum)
+                    ?.let { kd -> inputParam.addKdoc("%L", kd) }
+                functionBuilder.addParameter(inputParam.build())
             }
 
             functionBuilder.addParameter(
@@ -1182,6 +1227,7 @@ object ClassGenerator {
         val typeSpecBuilder = TypeSpec.classBuilder(className).addModifiers(KModifier.DATA)
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
             .addAnnotation(buildJsonIncludeAnnotationSpec())
+        KdocGenerator.forSchema(objectSchema)?.let { typeSpecBuilder.addKdoc("%L", it) }
         val constructorSpec = FunSpec.constructorBuilder()
         val requiredFields = objectSchema.required.orEmpty().toSet()
 
@@ -1200,6 +1246,7 @@ object ClassGenerator {
             val propertyBuilder = PropertySpec.builder(name, kotlinType)
                 .addAnnotation(buildJsonPropertyAnnotationSpec(property))
                 .initializer(name)
+            KdocGenerator.forSchema(schema)?.let { propertyBuilder.addKdoc("%L", it) }
             extractDeprecationNotice(schema)?.let { notice ->
                 propertyBuilder.addAnnotation(
                     buildDeprecatedAnnotationSpec(
@@ -1818,6 +1865,7 @@ object ClassGenerator {
         val typeSpecBuilder = TypeSpec.classBuilder(asClassName(propertyName))
             .addAnnotation(buildDittoJsonDslAnnotationSpec())
             .addAnnotation(buildJsonIncludeAnnotationSpec())
+        KdocGenerator.forSchema(objectSchema)?.let { typeSpecBuilder.addKdoc("%L", it) }
 
         superClass?.let {
             typeSpecBuilder.superclass(it)

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/EnumGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/clazz/EnumGenerator.kt
@@ -45,22 +45,25 @@ object EnumGenerator {
     ): String {
         val enumName = asClassName(propertyName!!)
         val enumValues = asListOf(enumArray, schemaType)
+        val kdoc = KdocGenerator.forSchema(propertySchema, includeAllowedValues = false)
         return when (schemaType) {
             DataSchemaType.INTEGER -> generateEnumWithProperty(
                 enumName,
                 enumValues,
-                LONG
+                LONG,
+                kdoc
             )
 
             DataSchemaType.NUMBER  -> generateEnumWithProperty(
                 enumName,
                 enumValues,
-                DOUBLE
+                DOUBLE,
+                kdoc
             )
 
-            DataSchemaType.STRING  -> generateStringEnum(enumName, enumValues)
+            DataSchemaType.STRING  -> generateStringEnum(enumName, enumValues, kdoc)
 
-            DataSchemaType.OBJECT  -> generateObjectEnum(propertySchema as ObjectSchema, enumName, enumArray)
+            DataSchemaType.OBJECT  -> generateObjectEnum(propertySchema as ObjectSchema, enumName, enumArray, kdoc)
 
             else                   -> throw IllegalArgumentException("Unsupported type for enum property $schemaType")
         }
@@ -111,11 +114,12 @@ object EnumGenerator {
     }
 
 
-    private fun generateStringEnum(enumName: String, enumValues: List<Any>): String {
+    private fun generateStringEnum(enumName: String, enumValues: List<Any>, kdoc: String? = null): String {
         val firstEnumValue = enumValues.first().toString()
         val isSimpleEnum = asEnumConstantName(enumName, firstEnumValue) == firstEnumValue
 
         val enumSpecBuilder = TypeSpec.enumBuilder(enumName)
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         if (isSimpleEnum) {
             enumValues.forEach {
@@ -165,7 +169,8 @@ object EnumGenerator {
     private fun generateEnumWithProperty(
         enumName: String,
         enumValues: List<Any>,
-        valueType: TypeName
+        valueType: TypeName,
+        kdoc: String? = null
     ): String {
         val enumSpecBuilder = TypeSpec.enumBuilder(enumName)
             .primaryConstructor(
@@ -174,6 +179,7 @@ object EnumGenerator {
                     .build()
             )
             .addProperty(PropertySpec.builder("_value", valueType).initializer("_value").build())
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         addCustomEnumConstants(enumSpecBuilder, enumName, enumValues, valueType)
 
@@ -204,11 +210,13 @@ object EnumGenerator {
     private fun generateObjectEnum(
         propertySchema: ObjectSchema,
         enumName: String,
-        enumArray: MutableSet<JsonValue>
+        enumArray: MutableSet<JsonValue>,
+        kdoc: String? = null
     ): String {
         val enumSpecBuilder = TypeSpec.classBuilder(enumName)
             .addModifiers(KModifier.SEALED)
             .addSuperinterface(JsonEnum::class)
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         val primaryConstructorBuilder = FunSpec.constructorBuilder()
         val propertiesCodeBuilder = CodeBlock.builder()

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/ConfigurationBuilder.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/ConfigurationBuilder.kt
@@ -37,6 +37,7 @@ class ConfigurationBuilder {
     private var generateSuspendDsl: Boolean = false
     private var generateEnums: Boolean = true
     private var generateInterfaces: Boolean = true
+    private var generateKdoc: Boolean = true
     private var submodelOnly: Boolean = false
     private var featureName: String? = null
     private var deduplicateReferencedTypes: Boolean = false
@@ -138,6 +139,14 @@ class ConfigurationBuilder {
     }
 
     /**
+     * Sets whether to render WoT metadata as KDoc on the generated code.
+     */
+    fun generateKdoc(generate: Boolean): ConfigurationBuilder {
+        this.generateKdoc = generate
+        return this
+    }
+
+    /**
      * Sets whether to generate a standalone submodel package instead of a full device model.
      */
     fun submodelOnly(generateStandaloneSubmodel: Boolean): ConfigurationBuilder {
@@ -216,6 +225,7 @@ class ConfigurationBuilder {
             generateSuspendDsl = generateSuspendDsl,
             generateEnums = generateEnums,
             generateInterfaces = generateInterfaces,
+            generateKdoc = generateKdoc,
             submodelOnly = submodelOnly,
             featureName = featureName,
             deduplicateReferencedTypes = deduplicateReferencedTypes

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/GeneratorConfiguration.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/config/GeneratorConfiguration.kt
@@ -50,6 +50,12 @@ data class GeneratorConfiguration(
     val generateInterfaces: Boolean = true,
 
     /**
+     * Whether to render WoT metadata (title, description, unit, semantic @type, value constraints, defaults,
+     * allowed values, ...) as KDoc on the generated properties, DSL builder functions, enums and action types.
+     */
+    val generateKdoc: Boolean = true,
+
+    /**
      * When true, generates a self-contained submodel package: feature classes, a single-feature
      * Features container, and a device-agnostic Thing — without attributes or multi-device wrappers.
      * Use for shared submodels referenced by multiple device types.
@@ -84,6 +90,7 @@ data class GeneratorConfiguration(
         generateSuspendDsl: Boolean? = null,
         generateEnums: Boolean? = null,
         generateInterfaces: Boolean? = null,
+        generateKdoc: Boolean? = null,
         submodelOnly: Boolean? = null,
         featureName: String? = null,
         deduplicateReferencedTypes: Boolean? = null
@@ -98,6 +105,7 @@ data class GeneratorConfiguration(
             generateSuspendDsl = generateSuspendDsl ?: this.generateSuspendDsl,
             generateEnums = generateEnums ?: this.generateEnums,
             generateInterfaces = generateInterfaces ?: this.generateInterfaces,
+            generateKdoc = generateKdoc ?: this.generateKdoc,
             submodelOnly = submodelOnly ?: this.submodelOnly,
             featureName = featureName ?: this.featureName,
             deduplicateReferencedTypes = deduplicateReferencedTypes ?: this.deduplicateReferencedTypes

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/dsl/DslGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/dsl/DslGenerator.kt
@@ -102,7 +102,8 @@ object DslGenerator {
         feature: String,
         featurePackage: String,
         isEntry: Boolean = false,
-        deprecationNotice: DeprecationNotice? = null
+        deprecationNotice: DeprecationNotice? = null,
+        kdoc: String? = null
     ): FunSpec {
         val className = ClassName(asPackageName(featurePackage), if (isEntry) feature else asClassName(feature))
         val propertyName = asPropertyName(feature)
@@ -129,6 +130,7 @@ object DslGenerator {
             .apply {
                 bodyStatements.forEach { addStatement(it) }
             }
+        kdoc?.let { funSpecBuilder.addKdoc("%L", it) }
         addDeprecationAnnotation(funSpecBuilder, deprecationNotice, withBlockParameter = true)
         return funSpecBuilder.build()
     }
@@ -191,6 +193,7 @@ object DslGenerator {
                     .addStatement("}")
                     .addStatement("$property!!.add($itemName)")
                     .addStatement("return $itemName")
+                KdocGenerator.forSchema(prop)?.let { funSpecBuilder.addKdoc("%L", it) }
                 addDeprecationAnnotation(funSpecBuilder, deprecationNotice, withBlockParameter = true)
                 funSpecBuilder.build()
             }
@@ -222,6 +225,7 @@ object DslGenerator {
                 .addStatement("$property.block()")
                 .addStatement("this.$property·=·$property")
                 .addStatement("return $property")
+            KdocGenerator.forSchema(prop)?.let { funSpecBuilder.addKdoc("%L", it) }
             addDeprecationAnnotation(funSpecBuilder, deprecationNotice, withBlockParameter = true)
             funSpecBuilder.build()
         }

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/PropertyResolver.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/property/PropertyResolver.kt
@@ -57,7 +57,7 @@ object PropertyResolver {
             val type = resolvePropertyType(it.value, parentPackage, role, feature, dittoCategory, propertyTmRef)
             Pair(
                 it.value,
-                createPropertySpec(it.key, type)
+                createPropertySpec(it.key, type, it.value)
             ) to dittoCategory
         }?.toMap()?.toMutableMap() ?: mutableMapOf()
     }
@@ -82,7 +82,7 @@ object PropertyResolver {
         return fields.map {
             val fieldTmRef = resolveTmRefForProperty(it.key, tmRefMap, it.value.toJson(), currentPropertiesPath)
             val poetType = schemaTypeResolver.resolveSchemaType(it.value, packageName, role, it.key, parentClassName, fieldTmRef)
-            it.key to createPropertySpec(it.key, poetType)
+            it.key to createPropertySpec(it.key, poetType, it.value)
         }
     }
 
@@ -116,7 +116,8 @@ object PropertyResolver {
                 listOf(
                     firstPropName to createPropertySpec(
                         firstPropName,
-                        ClassName(packageName, aliasClassName).copy(nullable = true)
+                        ClassName(packageName, aliasClassName).copy(nullable = true),
+                        oneOfProps[firstPropName]
                     )
                 )
             } else {
@@ -258,7 +259,8 @@ object PropertyResolver {
     // create property spec
     private fun createPropertySpec(
         name: String,
-        type: TypeName
+        type: TypeName,
+        schema: SingleDataSchema? = null
     ): PropertySpec {
         val propertyName = asPropertyName(name)
         val builder = PropertySpec.builder(propertyName, type.copy(nullable = true))
@@ -267,6 +269,7 @@ object PropertyResolver {
         if (propertyName != name) {
             builder.addAnnotation(buildJsonPropertyAnnotationSpec(name))
         }
+        KdocGenerator.forSchema(schema)?.let { builder.addKdoc("%L", it) }
         return builder.build()
     }
 

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/InlineEnumGenerationStrategy.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/InlineEnumGenerationStrategy.kt
@@ -55,19 +55,22 @@ class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
             "Item"
         }
         val enumValues = asListOf(enumArray, schemaType)
+        val kdoc = KdocGenerator.forSchema(propertySchema, includeAllowedValues = false)
         return when (schemaType) {
             DataSchemaType.INTEGER -> generateEnumWithProperty(
                 enumName,
                 enumValues,
-                LONG
+                LONG,
+                kdoc
             )
             DataSchemaType.NUMBER -> generateEnumWithProperty(
                 enumName,
                 enumValues,
-                DOUBLE
+                DOUBLE,
+                kdoc
             )
-            DataSchemaType.STRING -> generateStringEnum(enumName, enumValues)
-            DataSchemaType.OBJECT -> generateObjectEnum(propertySchema as ObjectSchema, enumName, enumArray)
+            DataSchemaType.STRING -> generateStringEnum(enumName, enumValues, kdoc)
+            DataSchemaType.OBJECT -> generateObjectEnum(propertySchema as ObjectSchema, enumName, enumArray, kdoc)
             else -> throw IllegalArgumentException("Unsupported type for enum property $schemaType")
         }
     }
@@ -142,10 +145,11 @@ class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
         return updatedFields
     }
 
-    private fun generateStringEnum(enumName: String, enumValues: List<Any>): String {
+    private fun generateStringEnum(enumName: String, enumValues: List<Any>, kdoc: String? = null): String {
         val firstEnumValue = enumValues.first().toString()
         val isSimpleEnum = asValidEnumConstant(firstEnumValue) == firstEnumValue
         val enumSpecBuilder = TypeSpec.enumBuilder(enumName)
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         if (isSimpleEnum) {
             enumValues.forEach {
@@ -187,7 +191,8 @@ class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
     private fun generateEnumWithProperty(
         enumName: String,
         enumValues: List<Any>,
-        valueType: TypeName
+        valueType: TypeName,
+        kdoc: String? = null
     ): String {
         val enumSpecBuilder = TypeSpec.enumBuilder(enumName)
             .primaryConstructor(
@@ -196,6 +201,7 @@ class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
                     .build()
             )
             .addProperty(PropertySpec.builder("_value", valueType).initializer("_value").build())
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         addCustomEnumConstants(enumSpecBuilder, enumName, enumValues, valueType)
 
@@ -218,11 +224,13 @@ class InlineEnumGenerationStrategy : IEnumGenerationStrategy {
     private fun generateObjectEnum(
         propertySchema: ObjectSchema,
         enumName: String,
-        enumArray: MutableSet<JsonValue>
+        enumArray: MutableSet<JsonValue>,
+        kdoc: String? = null
     ): String {
         val enumSpecBuilder = TypeSpec.classBuilder(enumName)
             .addModifiers(KModifier.SEALED)
             .addSuperinterface(JsonEnum::class)
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         val primaryConstructorBuilder = FunSpec.constructorBuilder()
         val propertiesCodeBuilder = CodeBlock.builder()

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/SeparateClassEnumGenerationStrategy.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/strategy/SeparateClassEnumGenerationStrategy.kt
@@ -92,21 +92,24 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         )
             ?: return enumName
 
+        val kdoc = KdocGenerator.forSchema(propertySchema, includeAllowedValues = false)
         val result = when (schemaType) {
             DataSchemaType.INTEGER -> generateEnumWithProperty(
                 resolvedEnumName,
                 enumValues,
                 LONG,
-                packageName
+                packageName,
+                kdoc
             )
             DataSchemaType.NUMBER -> generateEnumWithProperty(
                 resolvedEnumName,
                 enumValues,
                 DOUBLE,
-                packageName
+                packageName,
+                kdoc
             )
-            DataSchemaType.STRING -> generateStringEnum(resolvedEnumName, enumValues, packageName)
-            DataSchemaType.OBJECT -> generateObjectEnum(propertySchema as ObjectSchema, resolvedEnumName, enumArray, packageName)
+            DataSchemaType.STRING -> generateStringEnum(resolvedEnumName, enumValues, packageName, kdoc)
+            DataSchemaType.OBJECT -> generateObjectEnum(propertySchema as ObjectSchema, resolvedEnumName, enumArray, packageName, kdoc)
             else -> throw IllegalArgumentException("Unsupported type for enum property $schemaType")
         }
 
@@ -166,12 +169,13 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         return fields
     }
 
-    private fun generateStringEnum(enumName: String, enumValues: List<Any>, packageName: String): String {
+    private fun generateStringEnum(enumName: String, enumValues: List<Any>, packageName: String, kdoc: String? = null): String {
         val config = classGenerator.getConfig()
         val firstEnumValue = enumValues.first().toString()
         val isSimpleEnum = asEnumConstantName(enumName, firstEnumValue) == firstEnumValue
 
         val enumSpecBuilder = TypeSpec.enumBuilder(enumName)
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         val enumConstantNames = enumValues.map {
             asEnumConstantName(enumName, it.toString())
@@ -223,7 +227,8 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         enumName: String,
         enumValues: List<Any>,
         valueType: TypeName,
-        packageName: String
+        packageName: String,
+        kdoc: String? = null
     ): String {
         val config = classGenerator.getConfig()
         val enumSpecBuilder = TypeSpec.enumBuilder(enumName)
@@ -233,6 +238,7 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
                     .build()
             )
             .addProperty(PropertySpec.builder("_value", valueType).initializer("_value").build())
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         val enumConstantNames = enumValues.map {
             asEnumConstantName(enumName, it.toString())
@@ -267,12 +273,14 @@ class SeparateClassEnumGenerationStrategy : IEnumGenerationStrategy {
         propertySchema: ObjectSchema,
         enumName: String,
         enumArray: MutableSet<JsonValue>,
-        packageName: String
+        packageName: String,
+        kdoc: String? = null
     ): String {
         val config = classGenerator.getConfig()
         val enumSpecBuilder = TypeSpec.classBuilder(enumName)
             .addModifiers(KModifier.SEALED)
             .addSuperinterface(JsonEnum::class)
+        kdoc?.let { enumSpecBuilder.addKdoc("%L", it) }
 
         val primaryConstructorBuilder = FunSpec.constructorBuilder()
         val propertiesCodeBuilder = CodeBlock.builder()

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/KdocGenerator.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/main/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/KdocGenerator.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.util
+
+import org.eclipse.ditto.json.JsonPointer
+import org.eclipse.ditto.wot.model.SingleDataSchema
+import kotlin.jvm.optionals.getOrNull
+
+/**
+ * Builds KDoc documentation strings from WoT data schema metadata.
+ *
+ * WoT Thing Models carry rich, human- and machine-oriented metadata on properties, actions and data schemas
+ * (`title`, `description`, `unit`, semantic `@type`, value constraints, defaults, allowed values, ...). None of
+ * this survives into the generated Kotlin types unless it is rendered explicitly. This object turns that metadata
+ * into Markdown KDoc so it shows up on hover and during auto-completion in IDEs — for instance making it obvious
+ * that a `timeout` property is expressed in seconds rather than milliseconds.
+ *
+ * The produced text is plain Markdown (the format Dokka/IntelliJ render for KDoc). All values are emitted as
+ * literals by the callers (`addKdoc("%L", text)`) so that `%` characters in the model text are never interpreted
+ * as KotlinPoet format specifiers.
+ */
+object KdocGenerator {
+
+    /**
+     * Whether KDoc generation is enabled. Toggled once per generation run via [configure] from the
+     * [GeneratorConfiguration]'s `generateKdoc` flag.
+     */
+    @Volatile
+    var enabled: Boolean = true
+        private set
+
+    /**
+     * Numeric constraint fields, looked up from the schema JSON because a [org.eclipse.ditto.wot.model.Property] is
+     * not castable to the concrete numeric schema subtypes that expose typed getters for them.
+     */
+    private val numericConstraints = linkedMapOf(
+        "minimum" to "minimum",
+        "exclusiveMinimum" to "exclusive minimum",
+        "maximum" to "maximum",
+        "exclusiveMaximum" to "exclusive maximum",
+        "multipleOf" to "multiple of"
+    )
+
+    private val stringConstraints = linkedMapOf(
+        "minLength" to "min length",
+        "maxLength" to "max length",
+        "pattern" to "pattern",
+        "contentEncoding" to "content encoding",
+        "contentMediaType" to "content media type"
+    )
+
+    private val arrayConstraints = linkedMapOf(
+        "minItems" to "min items",
+        "maxItems" to "max items"
+    )
+
+    /**
+     * Configures whether KDoc should be generated for the current run.
+     *
+     * @param enabled whether KDoc generation is enabled.
+     */
+    fun configure(enabled: Boolean) {
+        this.enabled = enabled
+    }
+
+    /**
+     * Builds a Markdown KDoc string for the given WoT data schema (or property, which is a sub-type).
+     *
+     * @param schema the WoT data schema to document; may be {@code null}.
+     * @param includeAllowedValues whether to render the `enum` allowed values. Set to {@code false} when documenting
+     * a generated enum type, whose constants already represent the allowed values.
+     * @return the KDoc text, or {@code null} when KDoc generation is disabled, the schema is {@code null} or no
+     * documentable metadata is present.
+     */
+    fun forSchema(schema: SingleDataSchema?, includeAllowedValues: Boolean = true): String? {
+        if (!enabled || schema == null) {
+            return null
+        }
+
+        val json = schema.toJson()
+        val blocks = mutableListOf<String>()
+
+        schema.title.getOrNull()?.toString()?.takeIf { it.isNotBlank() }?.let { blocks.add(it.trim()) }
+        schema.description.getOrNull()?.toString()?.takeIf { it.isNotBlank() }?.let { blocks.add(it.trim()) }
+
+        val facts = mutableListOf<String>()
+        schema.unit.getOrNull()?.takeIf { it.isNotBlank() }?.let { facts.add("**Unit:** `$it`") }
+        schema.atType.getOrNull()?.toString()?.takeIf { it.isNotBlank() }
+            ?.let { facts.add("**Semantic type (`@type`):** `$it`") }
+        schema.format.getOrNull()?.takeIf { it.isNotBlank() }?.let { facts.add("**Format:** `$it`") }
+        schema.default.getOrNull()?.let { facts.add("**Default:** `${it.formatAsString()}`") }
+        schema.const.getOrNull()?.let { facts.add("**Constant value:** `${it.formatAsString()}`") }
+        if (includeAllowedValues && schema.enum.isNotEmpty()) {
+            facts.add("**Allowed values:** " + schema.enum.joinToString(", ") { "`${it.formatAsString()}`" })
+        }
+        if (schema.isReadOnly) {
+            facts.add("*Read-only.*")
+        }
+        if (schema.isWriteOnly) {
+            facts.add("*Write-only.*")
+        }
+        if (facts.isNotEmpty()) {
+            blocks.add(facts.joinToString("\n\n"))
+        }
+
+        val constraints = collectConstraints(json)
+        if (constraints.isNotEmpty()) {
+            blocks.add("**Constraints:**\n" + constraints.joinToString("\n") { " - ${it.first}: `${it.second}`" })
+        }
+
+        return blocks.takeIf { it.isNotEmpty() }?.joinToString("\n\n")
+    }
+
+    /**
+     * Builds a KDoc string from free-form text parts (e.g. an interaction's title and description), joining the
+     * non-blank parts with blank lines. Useful for elements that are not [SingleDataSchema]s, such as WoT actions.
+     *
+     * @param parts the text fragments to include; {@code null} or blank entries are skipped.
+     * @return the KDoc text, or {@code null} when KDoc generation is disabled or no text is present.
+     */
+    fun forText(vararg parts: String?): String? {
+        if (!enabled) {
+            return null
+        }
+        val blocks = parts.filterNotNull().map { it.trim() }.filter { it.isNotBlank() }
+        return blocks.takeIf { it.isNotEmpty() }?.joinToString("\n\n")
+    }
+
+    private fun collectConstraints(json: org.eclipse.ditto.json.JsonObject): List<Pair<String, String>> {
+        val result = mutableListOf<Pair<String, String>>()
+        (numericConstraints + stringConstraints + arrayConstraints).forEach { (field, label) ->
+            json.getValue(JsonPointer.of(field)).getOrNull()?.let { result.add(label to it.formatAsString()) }
+        }
+        return result
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/ActionOutputEnumGenerationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/ActionOutputEnumGenerationTest.kt
@@ -380,6 +380,78 @@ class ActionOutputEnumGenerationTest {
         }
     }
 
+    @Test
+    fun `top-level string enum action input uses generated enum not String`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-action-toplevel-input-enum-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "HVAC Controller",
+                      "version": { "model": "1.0.0" },
+                      "properties": {},
+                      "actions": {
+                        "changeMode": {
+                          "title": "Change mode",
+                          "description": "Changes the operational mode",
+                          "input": {
+                            "title": "Mode",
+                            "description": "The operational mode to apply",
+                            "type": "string",
+                            "enum": ["AUTO", "MANUAL", "OFF"]
+                          }
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.toplevelinputenumtest"
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val actionFile = outputDir.resolve("$packagePath/actions/ChangeMode.kt")
+
+            assertTrue(Files.exists(actionFile), "Expected generated action file at: $actionFile")
+
+            val content = Files.readString(actionFile)
+
+            // The input parameter should NOT be a raw String — it should be the generated enum
+            assertFalse(
+                Regex("""input:\s*String""").containsMatchIn(content),
+                "input should NOT be of type String, it should be an enum type. Generated content:\n$content"
+            )
+            assertTrue(
+                Regex("""input:\s*Mode""").containsMatchIn(content),
+                "input should be of type Mode (generated enum). Generated content:\n$content"
+            )
+            assertTrue(
+                content.contains("enum class Mode"),
+                "Expected Mode enum class to be generated. Generated content:\n$content"
+            )
+            assertTrue(content.contains("AUTO") && content.contains("MANUAL") && content.contains("OFF"),
+                "Expected enum constants AUTO/MANUAL/OFF. Generated content:\n$content")
+
+            // The redundant "Allowed values" KDoc line should be suppressed now that the type is an enum
+            assertFalse(
+                content.contains("Allowed values"),
+                "Allowed values KDoc should be suppressed for typed enum input. Generated content:\n$content"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
     private fun deleteRecursively(path: Path) {
         if (!Files.exists(path)) return
         Files.walk(path)

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/ObjectClassKdocGenerationTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/common/ObjectClassKdocGenerationTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.common
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.kotlin.generator.plugin.ThingModelGenerator
+import org.eclipse.ditto.wot.kotlin.generator.plugin.config.GeneratorConfiguration
+import org.eclipse.ditto.wot.model.ThingModel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that data classes generated from a WoT object schema carry class-level KDoc derived from the
+ * schema's title and description (e.g. an `Location` attribute object), not only their individual fields.
+ */
+class ObjectClassKdocGenerationTest {
+
+    @Test
+    fun `object property data class has class-level kdoc from schema title and description`() = runBlocking {
+        val outputDir = Files.createTempDirectory("wot-kotlin-object-class-kdoc-test")
+        try {
+            val thingModel = ThingModel.fromJson(
+                JsonObject.of(
+                    """
+                    {
+                      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+                      "@type": "tm:ThingModel",
+                      "title": "Asset",
+                      "version": { "model": "1.0.0" },
+                      "properties": {
+                        "location": {
+                          "title": "Location",
+                          "description": "The location of the asset",
+                          "type": "object",
+                          "properties": {
+                            "label": { "title": "Label", "type": "string" }
+                          }
+                        }
+                      }
+                    }
+                    """.trimIndent()
+                )
+            )
+            val outputPackage = "org.eclipse.ditto.wot.kotlin.generator.plugin.objectclasskdoctest"
+            ThingModelGenerator.generate(
+                thingModel,
+                GeneratorConfiguration(
+                    thingModelUrl = "in-memory",
+                    outputPackage = outputPackage,
+                    outputDirectory = outputDir.toFile()
+                )
+            )
+
+            val packagePath = outputPackage.replace('.', '/')
+            val locationFile = outputDir.resolve("$packagePath/attributes/Location.kt")
+            assertTrue(Files.exists(locationFile), "Expected generated Location class at: $locationFile")
+
+            val content = Files.readString(locationFile)
+
+            // Class-level KDoc must precede the data class declaration (before the annotations).
+            val kdocBeforeClass = Regex(
+                """/\*\*[\s\S]*?Location[\s\S]*?The location of the asset[\s\S]*?\*/[\s\S]*?public data class Location"""
+            )
+            assertTrue(
+                kdocBeforeClass.containsMatchIn(content),
+                "Expected class-level KDoc with title and description on Location. Generated content:\n$content"
+            )
+        } finally {
+            deleteRecursively(outputDir)
+        }
+    }
+
+    private fun deleteRecursively(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+}

--- a/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/KdocGeneratorTest.kt
+++ b/wot-kotlin-generator/wot-kotlin-generator-maven-plugin/src/test/kotlin/org/eclipse/ditto/wot/kotlin/generator/plugin/util/KdocGeneratorTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.kotlin.generator.plugin.util
+
+import org.eclipse.ditto.json.JsonObject
+import org.eclipse.ditto.wot.model.SingleDataSchema
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [KdocGenerator], verifying that WoT data-schema metadata is rendered into KDoc text.
+ */
+class KdocGeneratorTest {
+
+    @BeforeEach
+    fun enable() {
+        KdocGenerator.configure(true)
+    }
+
+    @AfterEach
+    fun reset() {
+        KdocGenerator.configure(true)
+    }
+
+    private fun schema(json: String): SingleDataSchema = SingleDataSchema.fromJson(JsonObject.of(json))
+
+    @Test
+    fun `renders title description and unit`() {
+        val kdoc = KdocGenerator.forSchema(
+            schema(
+                """
+                {
+                    "type": "integer",
+                    "title": "Timeout",
+                    "description": "Time to wait before giving up.",
+                    "unit": "s"
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertNotNull(kdoc)
+        assertTrue(kdoc!!.contains("Timeout"), "expected title, was: $kdoc")
+        assertTrue(kdoc.contains("Time to wait before giving up."), "expected description, was: $kdoc")
+        assertTrue(kdoc.contains("**Unit:** `s`"), "expected unit, was: $kdoc")
+    }
+
+    @Test
+    fun `renders numeric constraints from schema json`() {
+        val kdoc = KdocGenerator.forSchema(
+            schema(
+                """
+                {
+                    "type": "integer",
+                    "title": "Brightness",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "unit": "%"
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertNotNull(kdoc)
+        assertTrue(kdoc!!.contains("**Constraints:**"), "expected constraints block, was: $kdoc")
+        assertTrue(kdoc.contains("minimum: `0`"), "expected minimum, was: $kdoc")
+        assertTrue(kdoc.contains("maximum: `100`"), "expected maximum, was: $kdoc")
+    }
+
+    @Test
+    fun `renders default const and allowed values`() {
+        val kdoc = KdocGenerator.forSchema(
+            schema(
+                """
+                {
+                    "type": "string",
+                    "default": "medium",
+                    "enum": ["low", "medium", "high"]
+                }
+                """.trimIndent()
+            )
+        )
+
+        assertNotNull(kdoc)
+        assertTrue(kdoc!!.contains("**Default:** `medium`"), "expected default, was: $kdoc")
+        assertTrue(kdoc.contains("**Allowed values:**"), "expected allowed values, was: $kdoc")
+        assertTrue(kdoc.contains("`low`"), "expected enum value, was: $kdoc")
+    }
+
+    @Test
+    fun `omits allowed values when requested`() {
+        val kdoc = KdocGenerator.forSchema(
+            schema(
+                """
+                {
+                    "type": "string",
+                    "title": "Severity",
+                    "enum": ["low", "high"]
+                }
+                """.trimIndent()
+            ),
+            includeAllowedValues = false
+        )
+
+        assertNotNull(kdoc)
+        assertTrue(kdoc!!.contains("Severity"))
+        assertTrue(!kdoc.contains("Allowed values"), "should omit allowed values, was: $kdoc")
+    }
+
+    @Test
+    fun `returns null when no documentable metadata is present`() {
+        assertNull(KdocGenerator.forSchema(schema("""{"type": "boolean"}""")))
+    }
+
+    @Test
+    fun `returns null when disabled`() {
+        KdocGenerator.configure(false)
+        assertNull(
+            KdocGenerator.forSchema(
+                schema("""{"type": "integer", "title": "Timeout", "unit": "s"}""")
+            )
+        )
+    }
+
+    @Test
+    fun `returns null for null schema`() {
+        assertNull(KdocGenerator.forSchema(null))
+    }
+}


### PR DESCRIPTION
## Summary

Renders the rich metadata present in WoT Thing Models (title, description, **unit**, semantic `@type`, value constraints, defaults, `const`, allowed values, read/write-only) as Markdown **KDoc** on the generated Kotlin code, so context is visible on hover and during autocomplete in IDEs. For example, it becomes obvious that a `timeout`/`duration` is expressed in seconds rather than milliseconds.

## What's included

- **New `util/KdocGenerator`** — turns a `SingleDataSchema` (a `Property` is one) into KDoc. Values are emitted via `addKdoc("%L", …)` to avoid KotlinPoet treating `%` in model text as a format specifier.
- **New config flag `generateKdoc`** (default `true`) on `GeneratorConfiguration`, `ConfigurationBuilder` and the Mojo (`-DgenerateKdoc=false` to opt out).
- **KDoc wired into all generated elements:**
  - Data-class properties (attributes, features, object schemas)
  - DSL builder functions
  - Enums (class-level)
  - Action input/output data classes and action interface methods (incl. `@param input` with unit/constraints)
  - Thing root class + its `building {}`-style builder (from the model title/description)
  - Feature classes + their builders (from the referenced submodel TM)
  - Feature/attribute container accessor functions
  - Object-schema data classes (e.g. `Location`) and feature-property wrapper classes
- **Type-safety fix:** primitive `string`/`integer` **enum action inputs and outputs** are now generated as typed enums instead of raw `String`/`Long`, reusing the existing action enum path and respecting the INLINE/SEPARATE_CLASS strategy. The redundant "Allowed values" KDoc line is suppressed once the parameter is a typed enum (e.g. `changeMode(input: Mode, …)`).

## Testing

- New `KdocGeneratorTest`, `ObjectClassKdocGenerationTest`, and a top-level string-enum action-input case added to `ActionOutputEnumGenerationTest`.
- Full plugin module suite: **170 tests passing**, including integration tests that generate **and compile** real models with KDoc enabled.
- Verified end-to-end against a real downstream project (generation + compilation succeed; KDoc and typed enums present in output).

Closes #16
