### PR TITLE
enhancement: small improvements for open api generator

### DIFF
--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/WotLoader.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/WotLoader.kt
@@ -98,7 +98,6 @@ object WotLoader {
 
         openAPI.components(
             Components()
-                .schemas(errorProvider.provideDittoErrorSchemas())
                 .parameters(
                     mutableMapOf(
                         parametersProvider.resolveParameter(ParametersProvider.PATH_PARAM_THING_ID),
@@ -161,6 +160,8 @@ object WotLoader {
         }
 
         openAPI.paths(paths)
+
+        openAPI.components?.schemas?.putAll(errorProvider.provideDittoErrorSchemas())
 
         if (!Path("generated").isDirectory()) {
             Path("generated").createDirectory()

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/WotLoader.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/WotLoader.kt
@@ -103,7 +103,10 @@ object WotLoader {
                     mutableMapOf(
                         parametersProvider.resolveParameter(ParametersProvider.PATH_PARAM_THING_ID),
                         parametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_CONDITION),
-                        parametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_FIELDS)
+                        parametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_FIELDS),
+                        parametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_CHANNEL),
+                        parametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION),
+                        parametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY)
                     )
                 )
                 .securitySchemes(

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeatureActionsPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeatureActionsPathsGenerator.kt
@@ -54,10 +54,11 @@ object FeatureActionsPathsGenerator {
         val actionDeprecationNotice = extractDeprecationNotice(action)
         val deprecationNotice = actionDeprecationNotice ?: submodelDeprecationNotice
         val deprecated = deprecationNotice?.deprecated == true
+        val actionDisplayName = actionDisplayName(action)
 
         val operation = Operation()
             .also { if (deprecated) it.deprecated(true) }
-            .summary("Invokes the '${action.title.getOrNull()?.toString()}' action")
+            .summary("Invokes the '$actionDisplayName' action")
             .description(mergeWithDeprecationNotice(action.description.getOrNull()?.toString(), deprecationNotice))
             .tags(listOf("Feature: $featureTitle - Actions"))
             .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
@@ -66,7 +67,7 @@ object FeatureActionsPathsGenerator {
         provideInputSchema(action, featureName, openAPI)?.let { inputSchema ->
             operation.requestBody(
                 RequestBody()
-                    .description("Request payload of the '${action.title.getOrNull()?.toString()}' action")
+                    .description("Request payload of the '$actionDisplayName' action")
                     .content(
                         Content().addMediaType(
                             APPLICATION_JSON,
@@ -115,5 +116,8 @@ object FeatureActionsPathsGenerator {
         } else {
             null
         }
+
+    private fun actionDisplayName(action: Action): String =
+        action.title.getOrNull()?.toString()?.takeIf { it.isNotBlank() } ?: action.actionName
 
 }

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeaturesPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/features/FeaturesPathsGenerator.kt
@@ -84,6 +84,9 @@ object FeaturesPathsGenerator {
                 .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
                 .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_FIELDS) })
                 .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CONDITION) })
+                .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CHANNEL) })
+                .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION) })
+                .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY) })
                 .responses(
                     ApiResponses()
                         .addApiResponse(
@@ -116,6 +119,9 @@ object FeaturesPathsGenerator {
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_FIELDS) })
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CONDITION) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CHANNEL) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY) })
                         .responses(
                             ApiResponses()
                                 .addApiResponse(
@@ -161,6 +167,9 @@ object FeaturesPathsGenerator {
                     .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
                     .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_FIELDS) })
                     .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CONDITION) })
+                    .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CHANNEL) })
+                    .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION) })
+                    .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY) })
                     .responses(
                         ApiResponses()
                             .addApiResponse(

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/providers/ApiResponsesProvider.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/providers/ApiResponsesProvider.kt
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.wot.openapi.generator.providers
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.models.media.Content
 import io.swagger.v3.oas.models.media.MediaType
 import io.swagger.v3.oas.models.media.Schema
@@ -22,15 +23,27 @@ object ApiResponsesProvider {
 
     private const val APPLICATION_JSON = "application/json"
 
+    private val objectMapper = ObjectMapper()
+
+    private fun dittoErrorMediaType(example: DittoError) = MediaType()
+        .schema(Schema<Any>().apply {
+            `$ref`("#/components/schemas/dittoError")
+        })
+        .example(objectMapper.valueToTree(example))
+
     fun provide400ApiResponse(path: String): Pair<Int, ApiResponse> {
         return 400 to ApiResponse()
             .description("The request at '$path' failed due to bad input, check the error for details")
             .content(
                 Content().addMediaType(
-                    APPLICATION_JSON, MediaType()
-                        .schema(Schema<Any>().apply {
-                            `$ref`("dittoError_400")
-                        })
+                    APPLICATION_JSON, dittoErrorMediaType(
+                        DittoError(
+                            400,
+                            "things:id.invalid",
+                            "Thing ID 'nope' is not valid!",
+                            "It must conform to the namespaced entity ID notation (see Ditto documentation)"
+                        )
+                    )
                 )
             )
     }
@@ -40,10 +53,14 @@ object ApiResponsesProvider {
             .description("Unauthorized to access '$path'")
             .content(
                 Content().addMediaType(
-                    APPLICATION_JSON, MediaType()
-                        .schema(Schema<Any>().apply {
-                            `$ref`("dittoError_401")
-                        })
+                    APPLICATION_JSON, dittoErrorMediaType(
+                        DittoError(
+                            401,
+                            "gateway:authentication.failed",
+                            "The JWT was missing.",
+                            "Check if your credentials were correct."
+                        )
+                    )
                 )
             )
     }
@@ -53,10 +70,14 @@ object ApiResponsesProvider {
             .description("Forbidden to access '$path', ensure caller has required `WRITE` permissions")
             .content(
                 Content().addMediaType(
-                    APPLICATION_JSON, MediaType()
-                        .schema(Schema<Any>().apply {
-                            `$ref`("dittoError_403")
-                        })
+                    APPLICATION_JSON, dittoErrorMediaType(
+                        DittoError(
+                            403,
+                            "things:thing.notmodifiable",
+                            "The Thing with ID 'some:thing' could not be modified as the requester had insufficient permissions ('WRITE' is required).",
+                            "Check if the ID of your requested Thing was correct and you have sufficient permissions."
+                        )
+                    )
                 )
             )
     }
@@ -66,10 +87,14 @@ object ApiResponsesProvider {
             .description("Requested path '$path' does either not exist or caller has insufficient `READ` permissions")
             .content(
                 Content().addMediaType(
-                    APPLICATION_JSON, MediaType()
-                        .schema(Schema<Any>().apply {
-                            `$ref`("dittoError_404")
-                        })
+                    APPLICATION_JSON, dittoErrorMediaType(
+                        DittoError(
+                            404,
+                            "things:thing.notfound",
+                            "The Thing with ID 'some:thing' could not be found or requester had insufficient permissions to access it.",
+                            "Check if the ID of your requested Thing was correct and you have sufficient permissions."
+                        )
+                    )
                 )
             )
     }
@@ -79,10 +104,14 @@ object ApiResponsesProvider {
             .description("The request could not be completed due to timeout")
             .content(
                 Content().addMediaType(
-                    APPLICATION_JSON, MediaType()
-                        .schema(Schema<Any>().apply {
-                            `$ref`("dittoError_408")
-                        })
+                    APPLICATION_JSON, dittoErrorMediaType(
+                        DittoError(
+                            408,
+                            "command.timeout",
+                            "The Command reached the specified timeout of {10000}ms.",
+                            "Try increasing the command timeout."
+                        )
+                    )
                 )
             )
     }

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/providers/ErrorProvider.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/providers/ErrorProvider.kt
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.wot.openapi.generator.providers
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.models.media.IntegerSchema
 import io.swagger.v3.oas.models.media.ObjectSchema
 import io.swagger.v3.oas.models.media.Schema
@@ -21,67 +20,7 @@ import io.swagger.v3.oas.models.media.StringSchema
 object ErrorProvider {
 
     fun provideDittoErrorSchemas(): MutableMap<String, Schema<*>> =
-        mutableMapOf(
-            "dittoError_400" to dittoErrorObjectSchema()
-                .example(
-                    ObjectMapper().valueToTree(
-                        DittoError(
-                            400,
-                            "things:id.invalid",
-                            "Thing ID 'nope' is not valid!",
-                            "It must conform to the namespaced entity ID notation (see Ditto documentation)"
-                        )
-                    )
-                ),
-
-            "dittoError_401" to dittoErrorObjectSchema()
-                .example(
-                    ObjectMapper().valueToTree(
-                        DittoError(
-                            401,
-                            "gateway:authentication.failed",
-                            "The JWT was missing.",
-                            "Check if your credentials were correct."
-                        )
-                    )
-                ),
-
-            "dittoError_403" to dittoErrorObjectSchema()
-                .example(
-                    ObjectMapper().valueToTree(
-                        DittoError(
-                            403,
-                            "things:thing.notmodifiable",
-                            "The Thing with ID 'some:thing' could not be modified as the requester had insufficient permissions ('WRITE' is required).",
-                            "Check if the ID of your requested Thing was correct and you have sufficient permissions."
-                        )
-                    )
-                ),
-
-            "dittoError_404" to dittoErrorObjectSchema()
-                .example(
-                    ObjectMapper().valueToTree(
-                        DittoError(
-                            404,
-                            "things:thing.notfound",
-                            "The Thing with ID 'some:thing' could not be found or requester had insufficient permissions to access it.",
-                            "Check if the ID of your requested Thing was correct and you have sufficient permissions."
-                        )
-                    )
-                ),
-
-            "dittoError_408" to dittoErrorObjectSchema()
-                .example(
-                    ObjectMapper().valueToTree(
-                        DittoError(
-                            408,
-                            "command.timeout",
-                            "The Command reached the specified timeout of {10000}ms.",
-                            "Try increasing the command timeout."
-                        )
-                    )
-                )
-        )
+        mutableMapOf("dittoError" to dittoErrorObjectSchema())
 
     private fun dittoErrorObjectSchema() = ObjectSchema()
         .title("Ditto error")

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/providers/ParametersProvider.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/providers/ParametersProvider.kt
@@ -20,6 +20,9 @@ object ParametersProvider {
     const val PATH_PARAM_THING_ID = "PathParamThingId"
     const val QUERY_PARAM_FIELDS = "QueryParamFields"
     const val QUERY_PARAM_CONDITION = "QueryParamCondition"
+    const val QUERY_PARAM_CHANNEL = "QueryParamChannel"
+    const val QUERY_PARAM_LIVE_CHANNEL_CONDITION = "QueryParamLiveChannelCondition"
+    const val QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY = "QueryParamLiveChannelTimeoutStrategy"
 
     private val parameters: Map<String, Parameter> = mapOf(
         PATH_PARAM_THING_ID to Parameter()
@@ -85,7 +88,49 @@ object ParametersProvider {
             )
             .`in`("query")
             .required(false)
-            .schema(StringSchema())
+            .schema(StringSchema()),
+
+        QUERY_PARAM_CHANNEL to Parameter()
+            .name("channel")
+            .description(
+                """
+                    Defines to which channel to route the command: `twin` (digital twin) or `live` (the device).
+                    * If setting the channel parameter is omitted, the `twin` channel is set by default and the command is routed to the persisted representation of a thing in Eclipse Ditto.
+                    * When using the `live` channel, the command/message is sent towards the device.
+                """.trimIndent()
+            )
+            .`in`("query")
+            .required(false)
+            .schema(
+                StringSchema()
+                    ._enum(listOf("twin", "live"))
+            ),
+
+        QUERY_PARAM_LIVE_CHANNEL_CONDITION to Parameter()
+            .name("live-channel-condition")
+            .description(
+                """
+                    Defines that the request should fetch thing data via `live` channel if the given condition is met. The condition can be specified using RQL syntax.
+
+                    #### Examples
+
+                    * `?live-channel-condition=lt(_modified,"2021-12-24T12:23:42Z")`
+                    * `?live-channel-condition=ge(features/ConnectionStatus/properties/status/readyUntil,time:now)`
+                """.trimIndent()
+            )
+            .`in`("query")
+            .required(false)
+            .schema(StringSchema()),
+
+        QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY to Parameter()
+            .name("live-channel-timeout-strategy")
+            .description("Defines a strategy how to handle timeouts of a live response to a request sent via `channel=live` or with a matching live-channel-condition.")
+            .`in`("query")
+            .required(false)
+            .schema(
+                StringSchema()
+                    ._enum(listOf("fail", "use-twin"))
+            )
     )
 
     fun resolveParameter(paramKey: String) = paramKey to parameters[paramKey]

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/ActionsPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/ActionsPathsGenerator.kt
@@ -48,10 +48,11 @@ object ActionsPathsGenerator {
     private fun providePathForAction(action: Action, openAPI: OpenAPI): PathItem {
         val deprecationNotice = extractDeprecationNotice(action)
         val deprecated = deprecationNotice?.deprecated == true
+        val actionDisplayName = actionDisplayName(action)
 
         val operation = Operation()
             .also { if (deprecated) it.deprecated(true) }
-            .summary("Invokes the '${action.title.getOrNull()?.toString()}' action")
+            .summary("Invokes the '$actionDisplayName' action")
             .description(mergeWithDeprecationNotice(action.description.getOrNull()?.toString(), deprecationNotice))
             .tags(listOf("Actions"))
             .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
@@ -60,7 +61,7 @@ object ActionsPathsGenerator {
         provideInputSchema(action, openAPI)?.let { inputSchema ->
             operation.requestBody(
                 RequestBody()
-                    .description("Request payload of the '${action.title.getOrNull()?.toString()}' action")
+                    .description("Request payload of the '$actionDisplayName' action")
                     .content(
                         Content().addMediaType(
                             APPLICATION_JSON,
@@ -106,9 +107,12 @@ object ActionsPathsGenerator {
 
     private fun provideOutputSchema(action: Action, openAPI: OpenAPI) =
         if (action.output.isPresent) {
-            asOpenApiSchema(action.output.get(), null, "actioninput", openAPI)
+            asOpenApiSchema(action.output.get(), null, "actionoutput", openAPI)
         } else {
             null
         }
+
+    private fun actionDisplayName(action: Action): String =
+        action.title.getOrNull()?.toString()?.takeIf { it.isNotBlank() } ?: action.actionName
 
 }

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/AttributesPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/AttributesPathsGenerator.kt
@@ -58,6 +58,9 @@ object AttributesPathsGenerator {
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_FIELDS) })
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CONDITION) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CHANNEL) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY) })
                         .responses(
                             ApiResponses()
                                 .addApiResponse(
@@ -97,6 +100,9 @@ object AttributesPathsGenerator {
                     .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
                     .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_FIELDS) })
                     .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CONDITION) })
+                    .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CHANNEL) })
+                    .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION) })
+                    .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY) })
                     .responses(
                         ApiResponses()
                             .addApiResponse(

--- a/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/ThingPathsGenerator.kt
+++ b/wot-to-openapi-generator/src/main/kotlin/org/eclipse/ditto/wot/openapi/generator/thing/ThingPathsGenerator.kt
@@ -64,6 +64,9 @@ object ThingPathsGenerator {
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.PATH_PARAM_THING_ID) })
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_FIELDS) })
                         .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CONDITION) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_CHANNEL) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION) })
+                        .addParametersItem(Parameter().apply { `$ref`(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY) })
                         .responses(
                             ApiResponses()
                                 .addApiResponse(

--- a/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
+++ b/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
@@ -477,6 +477,60 @@ class DeprecationNoticeAndPathsTest {
         assertNull(propertyPath?.get?.deprecated)
     }
 
+    @Test
+    fun `thing action summary and payload description fall back to action name when title is missing`() {
+        val model = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "Device",
+              "actions": {
+                "requestDevicePageInfo": {
+                  "input": { "type": "object" }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        ActionsPathsGenerator.generateThingActionsPaths(model, paths, api)
+
+        val actionPost = paths["/{thingId}/inbox/messages/requestDevicePageInfo"]?.post
+        assertNotNull(actionPost)
+        assertEquals("Invokes the 'requestDevicePageInfo' action", actionPost.summary)
+        assertEquals("Request payload of the 'requestDevicePageInfo' action", actionPost.requestBody?.description)
+    }
+
+    @Test
+    fun `feature action summary and payload description fall back to action name when title is missing`() {
+        val featureModel = thingModelFromJson(
+            """
+            {
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "@type": "tm:ThingModel",
+              "title": "VideoRelay",
+              "actions": {
+                "requestDevicePageInfo": {
+                  "input": { "type": "object" }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val paths = Paths()
+        val api = openApi()
+        FeatureActionsPathsGenerator.generateFeatureActionsPaths("VideoRelay", featureModel, paths, api)
+
+        val actionPost = paths["/{thingId}/features/VideoRelay/inbox/messages/requestDevicePageInfo"]?.post
+        assertNotNull(actionPost)
+        assertEquals("Invokes the 'requestDevicePageInfo' action", actionPost.summary)
+        assertEquals("Request payload of the 'requestDevicePageInfo' action", actionPost.requestBody?.description)
+    }
+
     private fun thingModelFromJson(json: String): ThingModel =
         ThingModel.fromJson(JsonObject.of(json))
 

--- a/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
+++ b/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/DeprecationNoticeAndPathsTest.kt
@@ -22,6 +22,8 @@ import org.eclipse.ditto.wot.openapi.generator.features.FeaturesPathsGenerator
 import org.eclipse.ditto.wot.openapi.generator.thing.AttributeSchemaResolver
 import org.eclipse.ditto.wot.openapi.generator.thing.ActionsPathsGenerator
 import org.eclipse.ditto.wot.openapi.generator.thing.AttributesPathsGenerator
+import org.eclipse.ditto.wot.openapi.generator.thing.ThingPathsGenerator
+import org.eclipse.ditto.wot.openapi.generator.providers.ParametersProvider
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertContains
@@ -30,6 +32,71 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DeprecationNoticeAndPathsTest {
+
+  @Test
+  fun `get operations expose Ditto live channel query parameters`() {
+    val model = thingModelFromJson(
+      """
+      {
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "@type": "tm:ThingModel",
+        "title": "Thermostat",
+        "properties": {
+        "manufacturer": {
+          "title": "Manufacturer",
+          "type": "string"
+        }
+        }
+      }
+      """.trimIndent()
+    )
+
+    val api = openApi().components(
+      Components()
+        .schemas(mutableMapOf())
+        .parameters(
+          mutableMapOf(
+            ParametersProvider.resolveParameter(ParametersProvider.PATH_PARAM_THING_ID),
+            ParametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_FIELDS),
+            ParametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_CONDITION),
+            ParametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_CHANNEL),
+            ParametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION),
+            ParametersProvider.resolveParameter(ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY)
+          )
+        )
+    )
+    val paths = Paths()
+
+    ThingPathsGenerator.generateThingPaths(model, paths, api)
+    AttributesPathsGenerator.generateThingAttributesPaths(model, paths, api)
+    FeaturesPathsGenerator.generateFeaturesPaths("thermostat", model, paths, api)
+
+    val registeredParameters = api.components.parameters
+    assertNotNull(registeredParameters[ParametersProvider.QUERY_PARAM_CHANNEL])
+    assertNotNull(registeredParameters[ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION])
+    assertNotNull(registeredParameters[ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY])
+
+    val expectedRefs = setOf(
+      ParametersProvider.QUERY_PARAM_CHANNEL,
+      ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_CONDITION,
+      ParametersProvider.QUERY_PARAM_LIVE_CHANNEL_TIMEOUT_STRATEGY
+    )
+
+    listOf(
+      paths["/{thingId}"]?.get,
+      paths["/{thingId}/attributes"]?.get,
+      paths["/{thingId}/attributes/manufacturer"]?.get,
+      paths["/{thingId}/features/thermostat"]?.get,
+      paths["/{thingId}/features/thermostat/properties/manufacturer"]?.get
+    ).forEach { operation ->
+      val actualRefs = operation?.parameters
+        ?.mapNotNull { it.`$ref` }
+        ?.map { it.substringAfterLast('/') }
+        ?.toSet()
+        ?: emptySet()
+      assertTrue(expectedRefs.all(actualRefs::contains))
+    }
+  }
 
     @Test
     fun `extract valid deprecation notice and ignore invalid one`() {

--- a/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/providers/ErrorProviderTest.kt
+++ b/wot-to-openapi-generator/src/test/kotlin/org/eclipse/ditto/wot/openapi/generator/providers/ErrorProviderTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.openapi.generator.providers
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.Schema
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ErrorProviderTest {
+
+    @Test
+    fun `ditto error schemas are collapsed to a single shared component`() {
+        val schemas = ErrorProvider.provideDittoErrorSchemas()
+
+        assertEquals(listOf("dittoError"), schemas.keys.toList())
+
+        val schema = schemas["dittoError"]
+        assertNotNull(schema)
+        assertEquals("Ditto error", (schema as ObjectSchema).title)
+    }
+
+    @Test
+    fun `ditto error schema can be appended after existing schemas`() {
+        val openApi = OpenAPI().components(
+            Components().schemas(mutableMapOf<String, Schema<*>>("attributes" to ObjectSchema()))
+        )
+
+        openApi.components.schemas.putAll(ErrorProvider.provideDittoErrorSchemas())
+
+        assertEquals(listOf("attributes", "dittoError"), openApi.components.schemas.keys.toList())
+    }
+}


### PR DESCRIPTION
Please find this PR with some improvements on the open api generator. Each one is a separate commit, but I combined them into one PR. Let me know if that works for you:

- Added the `channel`, `live-channel-condition` and `live-channel-timeout-strategy` to the api docs. We are using `live` channel so this is an essential part of the open api docs
- `ditto error` schema was generated multiple times which looked not so nice. Reduced to just one entry for the ditto error and put this at the end of the list, so that all other schemas are mentioned first 
- Related to thing models not having a title property: I added a fallback to the property key in case no title is given:
<img width="1217" height="67" alt="image" src="https://github.com/user-attachments/assets/acded819-7b0f-4fd7-8648-3ee51807eebd" />
now works without title in the tm
